### PR TITLE
176894810/add summision text

### DIFF
--- a/app/assets/javascripts/osem.js
+++ b/app/assets/javascripts/osem.js
@@ -149,15 +149,21 @@ function word_count(text, divId, maxcount) {
 
 /* Wait for the DOM to be ready before attaching events to the elements */
 $( document ).ready(function() {
-    /* Set the minimum and maximum proposal abstract word length */
+    /* Set the minimum and maximum proposal abstract and submission text word length */
     $("#event_event_type_id").change(function () {
         var $selected = $("#event_event_type_id option:selected")
         var max = $selected.data("max-words");
         var min = $selected.data("min-words");
 
         $("#abstract-maximum-word-count").text(max);
+        $("#submission-maximum-word-count").text(max);
         $("#abstract-minimum-word-count").text(min);
+        $("#submission-minimum-word-count").text(min);
         word_count($('#event_abstract').get(0), 'abstract-count', max);
+        word_count($('#event_submission_text').get(0), 'submission-count', max);
+
+        // Set the placeholder text for the abstract
+        $('#event_submission_text').attr("placeholder", $selected.data("help"));
     })
         .trigger('change');
 
@@ -167,6 +173,13 @@ $( document ).ready(function() {
         var max = $selected.data("max-words");
         word_count(this, 'abstract-count', max);
     } );
+
+    /* Count the submission text length */
+    $("#event_submission_text").bind('change keyup paste input', function() {
+        var $selected = $("event_event_type_id option:selected")
+        var max = $selected.data("max-words");
+        word_count(this, 'submission-count', max);
+    });
 });
 
 /* Commodity function for modal windows */

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -175,7 +175,7 @@ module Admin
     def event_params
       params.require(:event).permit(
                                     # Set also in proposals controller
-                                    :title, :subtitle, :event_type_id, :abstract, :description, :require_registration, :difficulty_level_id,
+                                    :title, :subtitle, :event_type_id, :abstract, :submission_text, :description, :require_registration, :difficulty_level_id,
                                     # Set only in admin/events controller
                                     :track_id, :state, :language, :is_highlight, :max_attendees,
                                     # Not used anymore?

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -170,7 +170,7 @@ class ProposalsController < ApplicationController
 
   def event_params
     params.require(:event).permit(:event_type_id, :track_id, :difficulty_level_id,
-                                  :title, :subtitle, :abstract, :description,
+                                  :title, :subtitle, :abstract, :submission_text, :description,
                                   :require_registration, :max_attendees, :language,
                                   speaker_ids: [], volunteer_ids: []
                                  )

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -44,6 +44,7 @@ class Event < ApplicationRecord
   before_create :generate_guid
 
   validate :abstract_limit
+  validate :submission_limit
   validate :before_end_of_conference, on: :create
   validates :title, presence: true
   validates :abstract, presence: true
@@ -188,6 +189,10 @@ class Event < ApplicationRecord
     abstract.to_s.split.size
   end
 
+  def submission_word_count
+    submission_text.to_s.split.size
+  end
+
   def self.get_state_color(state)
     COLORS[state.to_sym] || '#00FFFF' # azure
   end
@@ -323,6 +328,18 @@ class Event < ApplicationRecord
 
     errors.add(:abstract, "cannot have less than #{min_words} words") if len < min_words
     errors.add(:abstract, "cannot have more than #{max_words} words") if len > max_words
+  end
+
+   def submission_limit
+    # If we don't have an event type, there is no need to count anything
+    return unless event_type && submission_text
+
+    len = submission_text.split.size
+    max_words = event_type.maximum_abstract_length
+    min_words = event_type.minimum_abstract_length
+
+    errors.add(:submission_text, "cannot have less than #{min_words} words") if len < min_words
+    errors.add(:submission_text, "cannot have more than #{max_words} words") if len > max_words
   end
 
   # TODO: create a module to be mixed into model to perform same operation

--- a/app/views/admin/events/_proposal.html.haml
+++ b/app/views/admin/events/_proposal.html.haml
@@ -113,6 +113,10 @@
           %td= markdown(@event.abstract)
         %tr
           %td
+            %b Submission Description
+          %td= markdown(@event.submission_text)
+        %tr
+          %td
             %b Requirements
           %td= simple_format(@event.description)
 

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -46,6 +46,20 @@
         250
       words.
 
+    = f.input :submission_text, input_html: { rows: 5, data: { provide: 'markdown' } },
+      hint: markdown_hint('[Tips to improve your presentations.](http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx)')
+
+    %p
+      You have used
+      %span#abstract-count #{@event.submission_word_count}
+      words.  Submission descriptions must be between
+      %span#abstract-minimum-word-count
+        0
+      and
+      %span#abstract-maximum-word-count
+        250
+      words.
+
     - if current_user.is_admin? or @program.cfp.enable_registrations?
       = f.inputs 'Enable pre-registration' do
         = f.input :require_registration, label: 'Require participants to register to your event'

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -13,7 +13,7 @@
 
     = f.input :event_type_id, as: :select,
       collection: @conference.program.event_types.map {|type| ["#{type.title} - #{show_time(type.length)}", type.id,
-      data: { min_words: type.minimum_abstract_length, max_words: type.maximum_abstract_length }]},
+      data: { min_words: type.minimum_abstract_length, max_words: type.maximum_abstract_length, help: type.description }]},
       include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' }
 
     - if @program.languages.present?
@@ -46,17 +46,19 @@
         250
       words.
 
-    = f.input :submission_text, input_html: { rows: 5, data: { provide: 'markdown' } },
-      hint: markdown_hint('[Tips to improve your presentations.](http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx)')
+    %br
+
+    = f.input :submission_text, input_html: { rows: 5, data: { provide: 'markdown' }, placeholder: '' },
+      hint: markdown_hint('Only conference organizers will read this.')
 
     %p
       You have used
-      %span#abstract-count #{@event.submission_word_count}
+      %span#submission-count #{@event.submission_word_count}
       words.  Submission descriptions must be between
-      %span#abstract-minimum-word-count
+      %span#submission-minimum-word-count
         0
       and
-      %span#abstract-maximum-word-count
+      %span#submission-maximum-word-count
         250
       words.
 

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -66,12 +66,12 @@
 
               %p
                 You have used
-                %span#abstract-count #{@event.submission_word_count}
+                %span#submission-count #{@event.submission_word_count}
                 words. Submission descriptions must be between
-                %span#abstract-minimum-word-count
+                %span#submission-minimum-word-count
                   0
                 and
-                %span#abstract-maximum-word-count
+                %span#submission-maximum-word-count
                   250
                 words.
 

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -61,6 +61,22 @@
                   250
                 words.
 
+              = f.input :submission_text, input_html: { rows: 5, data: { provide: 'markdown' } },
+                hint: markdown_hint
+
+              %p
+                You have used
+                %span#abstract-count #{@event.submission_word_count}
+                words. Submission descriptions must be between
+                %span#abstract-minimum-word-count
+                  0
+                and
+                %span#abstract-maximum-word-count
+                  250
+                words.
+
+
+
               - if @program.cfp.enable_registrations?
                 = f.input :require_registration, label: 'Require participants to register to your event'
 

--- a/db/migrate/20210215213515_add_submission_text_to_events.rb
+++ b/db/migrate/20210215213515_add_submission_text_to_events.rb
@@ -1,0 +1,5 @@
+class AddSubmissionTextToEvents < ActiveRecord::Migration[5.2]
+  def change
+  	add_column :events, :submission_text, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_16_181602) do
-
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+ActiveRecord::Schema.define(version: 2021_02_15_213515) do
 
   create_table "answers", force: :cascade do |t|
     t.string "title"
@@ -257,6 +254,7 @@ ActiveRecord::Schema.define(version: 2020_07_16_181602) do
     t.integer "program_id"
     t.integer "max_attendees"
     t.integer "comments_count", default: 0, null: false
+    t.text "submission_text"
   end
 
   create_table "events_registrations", force: :cascade do |t|

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -82,8 +82,9 @@ feature Event do
       fill_in 'event_title', with: 'Example Proposal'
       select('Example Event Type', from: 'event[event_type_id]')
       fill_in 'event_abstract', with: 'Lorem ipsum abstract'
+      fill_in 'event_submission_text', with: 'Lorem ipsum submission'
 
-      click_button 'Create Proposal'
+      click_button 'Submit Proposal'
       page.find('#flash')
       expect(page).to have_content 'Proposal was successfully submitted.'
 
@@ -123,10 +124,13 @@ feature Event do
       fill_in 'event_abstract', with: 'Lorem ipsum abstract'
       expect(page).to have_text('You have used 3 words')
 
+      fill_in 'event_submission_text', with: 'Lorem ipsum submission_text'
+      expect(page).to have_text('Submission description')
+
       click_link 'Do you require something special?'
       fill_in 'event_description', with: 'Lorem ipsum description'
 
-      click_button 'Create Proposal'
+      click_button 'Submit Proposal'
 
       page.find('#flash')
       expect(page).to have_content 'Proposal was successfully submitted.'


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**
#79 Proposals Should Have a "submission_text" field

<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->
79
-

**Changes proposed in this pull request:**

added submission_text field to event proposals

-
