### PR TITLE
Fixup the last trapeziod on social media section

### DIFF
--- a/app/assets/stylesheets/osem-splash.scss
+++ b/app/assets/stylesheets/osem-splash.scss
@@ -3,7 +3,8 @@
 
 #splash {
   // Counter the general padding for #content
-  margin-bottom: -60px;
+  margin-bottom: -65px;
+
   section {
     padding-top: 60px;
     padding-bottom: 60px;
@@ -142,6 +143,10 @@
         max-width: 280px;
       }
     }
+  }
+
+  .social-media.trapezoid {
+    border-top-color: #0C3559; // TODO: Use @conference color?
   }
 
   #social-media{

--- a/app/views/conferences/_social_media.haml
+++ b/app/views/conferences/_social_media.haml
@@ -27,4 +27,4 @@
           - if contact.email?
             = mail_to "#{ contact.email }" do
               %i.fa.fa-envelope-o.fa-4x
-    .trapezoid
+  .trapezoid.social-media


### PR DESCRIPTION
Minor tweak to get the last trapezoid colored correctly and fix some extra whitespace. 

<img width="1438" alt="Screen Shot 2021-03-02 at 6 57 25 PM" src="https://user-images.githubusercontent.com/1505907/109745727-2667b980-7b89-11eb-8dcc-5b4b7c93c687.png">
