### PR TITLE
Michael/add separate submission instructions

### DIFF
--- a/app/controllers/admin/event_types_controller.rb
+++ b/app/controllers/admin/event_types_controller.rb
@@ -49,7 +49,7 @@ module Admin
     private
 
     def event_type_params
-      params.require(:event_type).permit(:title, :length, :minimum_abstract_length, :maximum_abstract_length, :color, :conference_id, :description)
+      params.require(:event_type).permit(:title, :length, :minimum_abstract_length, :maximum_abstract_length, :submission_instructions, :color, :conference_id, :description)
     end
   end
 end

--- a/app/models/cfp.rb
+++ b/app/models/cfp.rb
@@ -14,7 +14,6 @@
 #  updated_at           :datetime
 #  program_id           :integer
 #
-# cannot delete program if there are events submitted
 
 class Cfp < ApplicationRecord
   TYPES = %w(events booths tracks).freeze

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,7 @@
 #  id                           :bigint           not null, primary key
 #  abstract                     :text
 #  comments_count               :integer          default(0), not null
+#  committee_review             :text
 #  description                  :text
 #  guid                         :string           not null
 #  is_highlight                 :boolean          default(FALSE)

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -10,6 +10,7 @@
 #  length                  :integer          default(30)
 #  maximum_abstract_length :integer          default(500)
 #  minimum_abstract_length :integer          default(0)
+#  submission_instructions :text
 #  title                   :string           not null
 #  created_at              :datetime
 #  updated_at              :datetime

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -22,7 +22,6 @@
 #
 #  index_programs_on_selected_schedule_id  (selected_schedule_id)
 #
-# cannot delete program if there are events submitted
 
 class Program < ApplicationRecord
   has_paper_trail on: [:update], ignore: [:updated_at], meta: { conference_id: :conference_id }

--- a/app/serializers/event_serializer.rb
+++ b/app/serializers/event_serializer.rb
@@ -7,6 +7,7 @@
 #  id                           :bigint           not null, primary key
 #  abstract                     :text
 #  comments_count               :integer          default(0), not null
+#  committee_review             :text
 #  description                  :text
 #  guid                         :string           not null
 #  is_highlight                 :boolean          default(FALSE)

--- a/app/views/admin/event_types/_form.html.haml
+++ b/app/views/admin/event_types/_form.html.haml
@@ -15,6 +15,7 @@
       = f.input :description, as: :text, hint: markdown_hint, input_html: { rows: 5, data: { provide: 'markdown-editable' } }
       = f.input :minimum_abstract_length, input_html: {size: 3}
       = f.input :maximum_abstract_length, input_html: {size: 3}
+      = f.input :submission_instructions, as: :text, hint: markdown_hint, input_html: { rows: 5, data: { provide: 'markdown-editable' } }
       = f.input :color, input_html: { size: 6, type: 'color' }
       %p.text-right
         = f.action :submit, as: :button, button_html: { class: 'btn btn-primary' }

--- a/app/views/admin/event_types/index.html.haml
+++ b/app/views/admin/event_types/index.html.haml
@@ -10,6 +10,7 @@
       %thead
         %th Title
         %th Description
+        %th Instructions
         %th Length
         %th Abstract Length
         %th Color
@@ -21,6 +22,8 @@
               = event_type.title
             %td
               = markdown(event_type.description)
+            %td
+              = markdown(event_type.submission_instructions)
             %td
               = event_type.length
               Minutes

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -47,20 +47,15 @@
       words.
 
     %br
+    - @conference.program.event_types.each do |event_type|
+      %span{ class: 'help-block select-help-text event_event_type_id collapse', id: "#{event_type.id}-help" }
+        %h3
+          = event_type.name
+          Instructions
+        = markdown(event_type.submission_instructions)
 
     = f.input :submission_text, input_html: { rows: 5, data: { provide: 'markdown' }, placeholder: '' },
       hint: markdown_hint('Only conference organizers will read this.')
-
-    %p
-      You have used
-      %span#submission-count #{@event.submission_word_count}
-      words.  Submission descriptions must be between
-      %span#submission-minimum-word-count
-        0
-      and
-      %span#submission-maximum-word-count
-        250
-      words.
 
     - if current_user.is_admin? or @program.cfp.enable_registrations?
       = f.inputs 'Enable pre-registration' do

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -68,7 +68,7 @@
                     = event_type.name
                     Instructions
                   %p Please use this as the template for your submission.
-                  This part of the submissions is intended only for the conference committee.
+                  This part of the submission is intended only for the conference committee.
                   %hr
                   = markdown(event_type.submission_instructions)
 

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -61,21 +61,20 @@
                   250
                 words.
 
+              %br
+              - @conference.program.event_types.each do |event_type|
+                %span{ class: 'help-block select-help-text event_event_type_id collapse', id: "#{event_type.id}-help" }
+                  %h3
+                    = event_type.name
+                    Instructions
+                  %p Please use this as the template for your submission.
+                  This part of the submissions is intended only for the conference committee.
+                  %hr
+                  = markdown(event_type.submission_instructions)
+
+
               = f.input :submission_text, input_html: { rows: 5, data: { provide: 'markdown' } },
                 hint: markdown_hint
-
-              %p
-                You have used
-                %span#submission-count #{@event.submission_word_count}
-                words. Submission descriptions must be between
-                %span#submission-minimum-word-count
-                  0
-                and
-                %span#submission-maximum-word-count
-                  250
-                words.
-
-
 
               - if @program.cfp.enable_registrations?
                 = f.input :require_registration, label: 'Require participants to register to your event'

--- a/db/migrate/20210306185903_add_submission_instructions_to_event_types.rb
+++ b/db/migrate/20210306185903_add_submission_instructions_to_event_types.rb
@@ -1,0 +1,5 @@
+class AddSubmissionInstructionsToEventTypes < ActiveRecord::Migration[5.2]
+  def change
+    add_column :event_types, :submission_instructions, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_15_213515) do
+ActiveRecord::Schema.define(version: 2021_03_06_185903) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
 
   create_table "answers", force: :cascade do |t|
     t.string "title"
@@ -219,6 +222,7 @@ ActiveRecord::Schema.define(version: 2021_02_15_213515) do
     t.integer "program_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.text "submission_instructions"
   end
 
   create_table "event_users", force: :cascade do |t|

--- a/spec/factories/event_types.rb
+++ b/spec/factories/event_types.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     minimum_abstract_length { 0 }
     maximum_abstract_length { 500 }
     description { 'Example Event Description' }
-    submission_instructions { 'Example Event Instructions'}
+    submission_instructions { 'Example Event Instructions' }
     color { '#ffffff' }
     program
   end

--- a/spec/factories/event_types.rb
+++ b/spec/factories/event_types.rb
@@ -10,6 +10,7 @@
 #  length                  :integer          default(30)
 #  maximum_abstract_length :integer          default(500)
 #  minimum_abstract_length :integer          default(0)
+#  submission_instructions :text
 #  title                   :string           not null
 #  created_at              :datetime
 #  updated_at              :datetime

--- a/spec/factories/event_types.rb
+++ b/spec/factories/event_types.rb
@@ -23,7 +23,7 @@ FactoryBot.define do
     length { 30 }
     minimum_abstract_length { 0 }
     maximum_abstract_length { 500 }
-    description { 'Example Event Description'}
+    description { 'Example Event Description' }
     submission_instructions { 'Example Event Instructions'}
     color { '#ffffff' }
     program

--- a/spec/factories/event_types.rb
+++ b/spec/factories/event_types.rb
@@ -23,6 +23,8 @@ FactoryBot.define do
     length { 30 }
     minimum_abstract_length { 0 }
     maximum_abstract_length { 500 }
+    description { 'Example Event Description'}
+    submission_instructions { 'Example Event Instructions'}
     color { '#ffffff' }
     program
   end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -7,6 +7,7 @@
 #  id                           :bigint           not null, primary key
 #  abstract                     :text
 #  comments_count               :integer          default(0), not null
+#  committee_review             :text
 #  description                  :text
 #  guid                         :string           not null
 #  is_highlight                 :boolean          default(FALSE)

--- a/spec/features/event_types_spec.rb
+++ b/spec/features/event_types_spec.rb
@@ -22,7 +22,8 @@ feature EventType do
 
       fill_in 'event_type_title', with: 'Party'
       fill_in 'event_type_length', with: '240'
-      fill_in 'event_type_description', with: '### This is a description'
+      fill_in 'event_type_description', with: '**Description**'
+      fill_in 'event_type_submission_instructions', with: '**Instructions**'
       fill_in 'event_type_minimum_abstract_length', with: '0'
       fill_in 'event_type_maximum_abstract_length', with: '13042'
       page.find('#event_type_color').set('#e4e4e4')
@@ -30,11 +31,14 @@ feature EventType do
       click_button 'Create Event type'
       page.find('#flash')
       # Validations
+      # binding.pry
       expect(flash).to eq('Event type successfully created.')
       within('table#event_types') do
         expect(page.has_content?('Party')).to be true
         expect(page.has_content?('13042')).to be true
         expect(page.has_content?('#E4E4E4')).to be true
+        expect(page.has_content?('Description')).to be true
+        expect(page.has_content?('Instructions')).to be true
         expect(page.assert_selector('tr', count: 3)).to be true
       end
 

--- a/spec/features/event_types_spec.rb
+++ b/spec/features/event_types_spec.rb
@@ -22,6 +22,7 @@ feature EventType do
 
       fill_in 'event_type_title', with: 'Party'
       fill_in 'event_type_length', with: '240'
+      fill_in 'event_type_description', with: '### This is a description'
       fill_in 'event_type_minimum_abstract_length', with: '0'
       fill_in 'event_type_maximum_abstract_length', with: '13042'
       page.find('#event_type_color').set('#e4e4e4')

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -136,11 +136,15 @@ feature Event do
       select('Example Event Type', from: 'event[event_type_id]')
       expect(page).to have_selector(".in[id='#{find_field('event[event_type_id]').value}-help']") # End of animation
 
+      expect(page).to have_text('Example Event Description')
       fill_in 'event_abstract', with: 'Lorem ipsum abstract'
       expect(page).to have_text('You have used 3 words')
 
       fill_in 'event_submission_text', with: 'Lorem ipsum submission_text'
-      expect(page).to have_text('Submission description')
+      expect(page).to have_text('Submission text')
+      # Submission Instructions content
+      expect(page).to have_text('Example Event Instructions')
+
 
       click_link 'Do you require something special?'
       fill_in 'event_description', with: 'Lorem ipsum description'

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -7,6 +7,7 @@
 #  id                           :bigint           not null, primary key
 #  abstract                     :text
 #  comments_count               :integer          default(0), not null
+#  committee_review             :text
 #  description                  :text
 #  guid                         :string           not null
 #  is_highlight                 :boolean          default(FALSE)

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -117,20 +117,6 @@ describe Event do
         event.event_type.minimum_abstract_length = 2
       end
 
-      context 'is invalid' do
-        it 'when submission text is too long' do
-          event.submission_text = 'four too many words'
-          expect(event.valid?).to eq false
-          expect(event.errors[:submission_text]).to eq ['cannot have more than 3 words']
-        end
-
-        it 'when submission text is too short' do
-          event.submission_text = 'word'
-          expect(event.valid?).to eq false
-          expect(event.errors[:submission_text]).to eq ['cannot have less than 2 words']
-        end
-      end
-
       context 'is valid' do
         it 'when submission text is within limts' do
           event.abstract = 'the magic three'

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -10,6 +10,7 @@
 #  length                  :integer          default(30)
 #  maximum_abstract_length :integer          default(500)
 #  minimum_abstract_length :integer          default(0)
+#  submission_instructions :text
 #  title                   :string           not null
 #  created_at              :datetime
 #  updated_at              :datetime

--- a/spec/serializers/event_serializer_spec.rb
+++ b/spec/serializers/event_serializer_spec.rb
@@ -7,6 +7,7 @@
 #  id                           :bigint           not null, primary key
 #  abstract                     :text
 #  comments_count               :integer          default(0), not null
+#  committee_review             :text
 #  description                  :text
 #  guid                         :string           not null
 #  is_highlight                 :boolean          default(FALSE)


### PR DESCRIPTION
* Adds a separate `submission_instructions` to an event_type
* Shows this new field on the proposals page above the `Submission text` input.
* Adds a couple tests.
* Removes the word count checks for submission text

<img width="1931" alt="Screen Shot 2021-03-08 at 2 14 37 AM" src="https://user-images.githubusercontent.com/1505907/110307678-0cc4d880-7fb4-11eb-8023-5e4fe883b256.png">
