### PR TITLE
Snap!Con Updates

### DIFF
--- a/app/assets/javascripts/osem.js
+++ b/app/assets/javascripts/osem.js
@@ -199,7 +199,7 @@ $( document ).ready(function() {
         let affirm = confirm($this.data('confirm'));
         if (affirm) {
             let sub_text = $('#event_submission_text');
-            sub_text.val($selected.data('help'));
+            sub_text.val($selected.data('instructions'));
             sub_text.trigger('change');
         }
     });

--- a/app/assets/javascripts/osem.js
+++ b/app/assets/javascripts/osem.js
@@ -49,6 +49,8 @@ $(function () {
         $('.' + id).collapse('hide');
 
         $('#' + $(this).val() + '-help.' + id).collapse('show');
+        $('#' + $(this).val() + '-instructions.' + id).collapse('show');
+
     });
     $('.dropdown-toggle').dropdown();
 
@@ -165,7 +167,7 @@ $( document ).ready(function() {
         var min = $selected.data("min-words");
 
         // Set the filler text for the submission text
-        fill_if_empty('event_submission_text', $selected.data("help"));
+        fill_if_empty('event_submission_text', $selected.data("instructions"));
 
         $("#abstract-maximum-word-count").text(max);
         $("#submission-maximum-word-count").text(max);

--- a/app/assets/javascripts/osem.js
+++ b/app/assets/javascripts/osem.js
@@ -175,8 +175,7 @@ $( document ).ready(function() {
         $("#submission-minimum-word-count").text(min);
         word_count($('#event_abstract').get(0), 'abstract-count', max);
         word_count($('#event_submission_text').get(0), 'submission-count', max);
-    })
-        .trigger('change');
+    }).trigger('change');
 
     /* Count the proposal abstract length */
     $("#event_abstract").bind('change keyup paste input', function() {
@@ -193,7 +192,7 @@ $( document ).ready(function() {
     });
 
     /* Listen for reset template button, wait for confirm, and reset. */
-    $('#sub_text_reset').click((e) => {
+    $('.js-resetSubmissionText').click((e) => {
         let $selected = $("#event_event_type_id option:selected");
         let $this = $(e.target);
         let affirm = confirm($this.data('confirm'));

--- a/app/assets/stylesheets/osem-dashboard.scss
+++ b/app/assets/stylesheets/osem-dashboard.scss
@@ -1,26 +1,34 @@
 @import "breakpoints.scss";
 
 .dashbox span.fa {
-  line-height: 1.1em;
+  margin-bottom: 2px;
+
+  @include breakpoint(xs) {
+    font-size: 1.5em;
+  }
   @include breakpoint(sm) {
-    font-size: 3em;
+    font-size: 2em;
   }
   @include breakpoint(md) {
-    font-size: 4em;
+    font-size: 3.5em;
   }
   @include breakpoint(lg) {
     font-size: 5em;
   }
 }
 
-.dashbox {
-    padding-top: 20px;
-    padding-bottom: 20px;
-}
+.dashbox.panel {
+    padding: 10px;
+    display: -webkit-flex;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.4rem;
+    line-height: 1.6rem;
 
-.dashbox label {
-    display: block;
-    font-size: 1.1em;
+    label {
+      line-height: 2rem;
+    }
 }
 
 .todolist-missing span {

--- a/app/controllers/admin/conferences_controller.rb
+++ b/app/controllers/admin/conferences_controller.rb
@@ -124,8 +124,7 @@ module Admin
       #   current_user.last_sign_in_at
       # ).count
 
-      #  Step by step list
-      # @conference_progress = @conference.get_status
+      @conference_todo_list = @conference.get_status
 
       # Line charts
       @registrations = @conference.get_registrations_per_week

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -66,8 +66,8 @@ module EventsHelper
         "#{type.title} - #{show_time(type.length)}",
         type.id,
         data: {
-          min_words: type.minimum_abstract_length,
-          max_words: type.maximum_abstract_length,
+          min_words:    type.minimum_abstract_length,
+          max_words:    type.maximum_abstract_length,
           instructions: type.submission_instructions
         }
       ]

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -60,6 +60,19 @@ module EventsHelper
     "#{event.average_rating}/#{max_rating}, #{pluralize(event.voters.length, 'vote')}"
   end
 
+  def event_type_options(event_types)
+    event_types.map do |type|
+      [
+        "#{type.title} - #{show_time(type.length)}",
+        type.id,
+        data: {
+          min_words: type.minimum_abstract_length,
+          max_words: type.maximum_abstract_length,
+          help: type.submission_instructions
+        }
+      ]
+    end
+  end
   def event_type_dropdown(event, event_types, conference_id)
     selection = event.event_type.try(:title) || 'Event Type'
     options = event_types.collect do |event_type|

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -68,7 +68,7 @@ module EventsHelper
         data: {
           min_words: type.minimum_abstract_length,
           max_words: type.maximum_abstract_length,
-          help: type.submission_instructions
+          instructions: type.submission_instructions
         }
       ]
     end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -73,6 +73,7 @@ module EventsHelper
       ]
     end
   end
+
   def event_type_dropdown(event, event_types, conference_id)
     selection = event.event_type.try(:title) || 'Event Type'
     options = event_types.collect do |event_type|

--- a/app/mailers/mailbot.rb
+++ b/app/mailers/mailbot.rb
@@ -7,8 +7,9 @@ YTLF_TICKET_ID = 50
 class Mailbot < ActionMailer::Base
   helper ConferenceHelper
 
-  default bcc:           -> { SNAPCON_BCC_ADDRESS },
-          template_name: -> { EMAIL_TEMPLATE },
+  default bcc:           SNAPCON_BCC_ADDRESS,
+          template_name: EMAIL_TEMPLATE,
+          content_type:  'text/html',
           to:            -> { @user.email },
           from:          -> { @conference.contact.email }
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -273,7 +273,7 @@ class Event < ApplicationRecord
       biographies:      speakers.all? { |speaker| !speaker.biography.blank? },
       subtitle:         !subtitle.blank?,
       track:            (!track.blank? unless program.tracks.empty?),
-      difficulty_level: !difficulty_level.blank?,
+      difficulty_level: (difficulty_level.present? unless program.difficulty_levels.empty?),
       title:            true,
       abstract:         true
     }.with_indifferent_access

--- a/app/views/admin/conferences/_todo_list.html.haml
+++ b/app/views/admin/conferences/_todo_list.html.haml
@@ -1,13 +1,14 @@
-.list-group
-  %li{ 'class' => "list-group-item #{hidden_if_conference_over(conference)}" }
+%ul.list-group
+  .list-group-item
     %h4
       Conference progress
     .progress
-      .progress-bar{ 'role' => 'progressbar', 'aria-valuenow' => "#{conference_progress['process']}", 'aria-valuemin' => '0',
-                    'aria-valuemax' => '100', 'style' => "width: #{conference_progress['process']}%;" }
+      .progress-bar{ role: 'progressbar', 'aria-valuenow': conference_progress['process'],
+                     'aria-valuemin': 0, 'aria-valuemax': 100,
+                     style: "width: #{conference_progress['process']}%;" }
         = conference_progress['process'] + '%'
-  %li{ 'class' => "list-group-item #{hidden_if_conference_over(conference)}  #{class_for_todo(conference_progress['registration'])}" }
-    %span{ 'class' => icon_for_todo(conference_progress['registration']) }
+  %li.list-group-item{ class: class_for_todo(conference_progress['registration']) }
+    %span{ class: icon_for_todo(conference_progress['registration']) }
     - if can? :update, @conference
       - if conference.registration_period
         = link_to 'Set up registration period', edit_admin_conference_registration_period_path(conference_progress['short_title'])
@@ -15,14 +16,14 @@
         = link_to 'Set up registration period', new_admin_conference_registration_period_path(conference_progress['short_title'])
     - else
       Set up registration period
-  %li{ 'class' => "list-group-item #{hidden_if_conference_over(conference)}  #{class_for_todo(conference_progress['cfp'])}" }
-    %span{ 'class' => icon_for_todo(conference_progress['cfp']) }
+  %li.list-group-item{ class: class_for_todo(conference_progress['cfp']) }
+    %span{ class: icon_for_todo(conference_progress['cfp']) }
     - if can? :update, Cfp.new(program_id: @program.id)
       = link_to 'Set up call for papers', admin_conference_program_cfps_path(conference_progress['short_title'])
     - else
       Set up call for papers
-  %li{'class'=>"list-group-item #{hidden_if_conference_over(conference)} #{class_for_todo(conference_progress['venue'])}"}
-    %span{'class'=>icon_for_todo(conference_progress['venue'])}
+  %li.list-group-item{ class: class_for_todo(conference_progress['venue']) }
+    %span{ class: icon_for_todo(conference_progress['venue'])}
     - if can? :update, Venue.new(conference: @conference)
       - @conference.reload
       - if conference.venue
@@ -32,32 +33,32 @@
     - else
       - @conference.reload
       Add venue
-  %li{ 'class' => "list-group-item #{hidden_if_conference_over(conference)} #{class_for_todo(conference_progress['rooms'])}" }
-    %span{ 'class' => icon_for_todo(conference_progress['rooms']) }
+  %li.list-group-item{ class: class_for_todo(conference_progress['rooms']) }
+    %span{ class: icon_for_todo(conference_progress['rooms']) }
     - if @conference.venue && (can? :update, @conference.venue.rooms.build)
       = link_to 'Add rooms', admin_conference_venue_rooms_path(conference_progress['short_title'])
     - else
       Add rooms
-  %li{ 'class' => "list-group-item #{hidden_if_conference_over(conference)} #{class_for_todo(conference_progress['tracks'])}" }
-    %span{ 'class' => icon_for_todo(conference_progress['tracks']) }
+  %li.list-group-item{ class: class_for_todo(conference_progress['tracks']) }
+    %span{ class: icon_for_todo(conference_progress['tracks']) }
     - if can? :update, @conference.program.tracks.build
       = link_to 'Add tracks', admin_conference_program_tracks_path(conference_progress['short_title'])
     - else
       Add tracks
-  %li{ 'class' => "list-group-item #{hidden_if_conference_over(conference)} #{class_for_todo(conference_progress['event_types'])}" }
-    %span{ 'class' => icon_for_todo(conference_progress['event_types']) }
+  %li{ class: "list-group-item #{class_for_todo(conference_progress['event_types'])}" }
+    %span{ class: icon_for_todo(conference_progress['event_types']) }
     - if can? :update, @conference.program.event_types.build
       = link_to 'Add event types', admin_conference_program_event_types_path(conference_progress['short_title'])
     - else
       Add event types
-  %li{ 'class' => "list-group-item #{hidden_if_conference_over(conference)} #{class_for_todo(conference_progress['difficulty_levels'])}" }
-    %span{ 'class' => icon_for_todo(conference_progress['difficulty_levels']) }
+  %li{ class: "list-group-item #{class_for_todo(conference_progress['difficulty_levels'])}" }
+    %span{ class: icon_for_todo(conference_progress['difficulty_levels']) }
     - if can? :update, @conference.program.difficulty_levels.build
       = link_to 'Add difficulty levels', admin_conference_program_difficulty_levels_path(conference_progress['short_title'])
     - else
       Add difficulty levels
-  %li{ class: "list-group-item #{hidden_if_conference_over(conference)} #{class_for_todo(conference_progress['splashpage'])}" }
-    %span{ 'class' => icon_for_todo(conference_progress['splashpage']) }
+  %li.list-group-item{ class: "#{class_for_todo(conference_progress['splashpage'])}" }
+    %span{ class: icon_for_todo(conference_progress['splashpage']) }
     - if can? :update, @conference
       = link_to 'Set up a Splashpage', admin_conference_splashpage_path(conference_progress['short_title'])
     - else

--- a/app/views/admin/conferences/edit.html.haml
+++ b/app/views/admin/conferences/edit.html.haml
@@ -9,24 +9,27 @@
     = semantic_form_for(@conference, url: admin_conference_path(@conference.short_title), html: {multipart: true}) do |f|
       = f.input :title, hint: "The full title of the conference, e.g. 'openSUSE Conference 2014'"
       = f.input :short_title, hint: "A short title, e.g. 'oSC14', to be used in URLs"
-      = f.input :description, hint: markdown_hint('A description of the conference. This supports unsafe HTML and JavaScript.'), input_html: { rows: 5, data: { provide: 'markdown' } }
-      = f.input :color, hint: 'The color will be used eg for the dashboard.', input_html: {size: 6, type: 'color'}
-      = f.label 'Conference Logo'
+      = f.input :description,
+                hint: markdown_hint('A description of the conference. (Supports unsafe HTML.)'),
+                input_html: { rows: 5, data: { provide: 'markdown' } }
+      = f.input :color, hint: 'The will be used in emails.',
+                input_html: {size: 6, type: 'color'}
+      = f.label 'Conference Logo', for: 'conference_picture'
       %br
       - if @conference.picture?
         = image_tag @conference.picture.thumb.url
-      = f.input :picture, label: false, hint: 'This will be displayed on the front page.'
+      = f.input :picture, label: false, hint: 'This will be shown in the navigation bar and emails.'
       = f.hidden_field :picture_cache
 
       = f.input :custom_css,
-        hint: "Add custon CSS to all pages within the conference. The class <code>.conference-#{@conference.short_title}</code> is included on the body element.".html_safe,
-        input_html: { rows: 10, style: 'font-family: monospace' }
+                hint: "Add custon CSS to all pages within the conference. The class <code>.conference-#{@conference.short_title}</code> is included on the body element.".html_safe,
+                input_html: { rows: 10, style: 'font-family: monospace' }
 
       = f.input :ticket_layout, as: :select, collection: Conference.ticket_layouts.keys, hint: "Layout type for tickets of the conference."
       = f.inputs name: 'Scheduling' do
         = f.input :timezone, as: :time_zone, hint: 'The conference time zone'
-        = f.input :start_date, as: :string, input_html: { id: 'conference-start-datepicker', readonly: 'readonly' }
-        = f.input :end_date, as: :string, input_html: { id: 'conference-end-datepicker', readonly: 'readonly' }
+        = f.input :start_date, as: :string, input_html: { id: 'conference-start-datepicker' }
+        = f.input :end_date, as: :string, input_html: { id: 'conference-end-datepicker' }
         = f.input :start_hour, input_html: {size: 2, type: 'number', min: 0, max: 23}, hint: rescheduling_hint(@affected_event_count)
         = f.input :end_hour, input_html: {size: 2, type: 'number', min: 1, max: 24}, hint: rescheduling_hint(@affected_event_count)
       = f.inputs name: 'Registrations' do

--- a/app/views/admin/conferences/edit.html.haml
+++ b/app/views/admin/conferences/edit.html.haml
@@ -9,7 +9,7 @@
     = semantic_form_for(@conference, url: admin_conference_path(@conference.short_title), html: {multipart: true}) do |f|
       = f.input :title, hint: "The full title of the conference, e.g. 'openSUSE Conference 2014'"
       = f.input :short_title, hint: "A short title, e.g. 'oSC14', to be used in URLs"
-      = f.input :description, hint: markdown_hint('A description of the conference.'), input_html: { rows: 5, data: { provide: 'markdown' } }
+      = f.input :description, hint: markdown_hint('A description of the conference. This supports unsafe HTML and JavaScript.'), input_html: { rows: 5, data: { provide: 'markdown' } }
       = f.input :color, hint: 'The color will be used eg for the dashboard.', input_html: {size: 6, type: 'color'}
       = f.label 'Conference Logo'
       %br
@@ -19,8 +19,8 @@
       = f.hidden_field :picture_cache
 
       = f.input :custom_css,
-        hint: "Add Custon CSS to the main page. You might find the class '.conference-#{@conference.short_title}' useful.",
-        input_html: { rows: 5 }
+        hint: "Add custon CSS to all pages within the conference. The class <code>.conference-#{@conference.short_title}</code> is included on the body element.".html_safe,
+        input_html: { rows: 10, style: 'font-family: monospace' }
 
       = f.input :ticket_layout, as: :select, collection: Conference.ticket_layouts.keys, hint: "Layout type for tickets of the conference."
       = f.inputs name: 'Scheduling' do

--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -32,6 +32,17 @@
         - unless @conference.ended?
           = render 'todo_list',
             conference_progress: @conference_todo_list, conference: @conference
+        - else
+          .list-group
+            .list-group-item
+              %h4
+                Conference Progress
+              .progress
+                .progress-bar{ role: 'progressbar', 'aria-valuenow': 100,
+                              'aria-valuemin': 0, 'aria-valuemax': 100,
+                              style: 'width: 100%;' }
+                  Conference Complete!
+
       .row#tickets
         .col-md-8
           = render 'line_chart',
@@ -60,11 +71,11 @@
             = render 'donut_chart', title: 'Event types',
               combined_data: @event_type_distribution
           .col-md-4
-              = render 'donut_chart', title: 'Difficulty levels',
-                combined_data: @difficulty_levels_distribution
+            = render 'donut_chart', title: 'Difficulty levels',
+              combined_data: @difficulty_levels_distribution
           .col-md-4
-              = render 'donut_chart', title: 'Tracks',
-                combined_data: @tracks_distribution
+            = render 'donut_chart', title: 'Tracks',
+              combined_data: @tracks_distribution
       -# .tab-pane#distribution_withdrawn
         .row
           .col-md-4

--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -3,16 +3,16 @@
   Dashboard for #{@conference.title}
 %hr
 .row
-  .col-sm-3.col-xs-3
+  .col-sm-3
     = render "big_statistic",
       icon: "user", subtitle: "Registration", value: @total_reg, delta: @new_reg
-  .col-sm-3.col-xs-3
+  .col-sm-3
     = render "big_statistic",
       icon: "check-square", subtitle: "Submission", value: @total_submissions, delta: @new_submissions
-  .col-sm-3.col-xs-3
+  .col-sm-3
     = render "big_statistic",
       icon: "file-text", subtitle: "Hour", value: @program_length, delta: @new_program_length
-  .col-sm-3.col-xs-3
+  .col-sm-3
     = render "big_statistic",
       icon: "archive", subtitle: "Withdrawn", value: @total_withdrawn, delta: @new_withdrawn
 

--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -28,9 +28,10 @@
           .col-md-12
             = render 'line_chart',
               title: 'Submissions per week', data: @submissions
-      -# .col-md-4
-        = render 'todo_list',
-          conference_progress: @conference_progress, conference: @conference
+      .col-md-4
+        - unless @conference.ended?
+          = render 'todo_list',
+            conference_progress: @conference_todo_list, conference: @conference
       .row#tickets
         .col-md-8
           = render 'line_chart',

--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -29,8 +29,8 @@
             = render 'line_chart',
               title: 'Submissions per week', data: @submissions
       -# .col-md-4
-      -#   = render 'todo_list',
-      -#     conference_progress: @conference_progress, conference: @conference
+        = render 'todo_list',
+          conference_progress: @conference_progress, conference: @conference
       .row#tickets
         .col-md-8
           = render 'line_chart',
@@ -43,14 +43,15 @@
         %a{ href: '#distribution_all', 'data-toggle' => 'tab' }
           %span.fa.fa-star
           All
-      -# %li
-      -#   %a{ href: '#distribution_confirmed', 'data-toggle' => 'tab' }
-      -#     %span.fa.fa-comment
-      -#     Confirmed
-      -# %li
-      -#   %a{ href: '#distribution_withdrawn', 'data-toggle' => 'tab' }
-      -#     %span.fa.fa-archive
-      -#     Withdrawn
+      -# TODO-SNAP: Disabled for Snap!Con
+        %li
+          %a{ href: '#distribution_confirmed', 'data-toggle' => 'tab' }
+            %span.fa.fa-comment
+            Confirmed
+        %li
+          %a{ href: '#distribution_withdrawn', 'data-toggle' => 'tab' }
+            %span.fa.fa-archive
+            Withdrawn
     .tab-content
       .tab-pane.active#distribution_all
         .row
@@ -91,27 +92,27 @@
             = render 'donut_chart', title: 'Tracks',
               combined_data: @tracks_distribution
       -# .tab-pane#distribution_confirmed
-      -#   .row
-      -#     .col-md-4
-      -#       = render 'donut_chart', title: 'Event types',
-      -#         combined_data: @event_type_distribution_confirmed
-      -#     .col-md-4
-      -#       = render 'donut_chart', title: 'Difficulty levels',
-      -#         combined_data: @difficulty_levels_distribution_confirmed
-      -#     .col-md-4
-      -#       = render 'donut_chart', title: 'Tracks',
-      -#         combined_data: @tracks_distribution_confirmed
-      -# .tab-pane#distribution_withdrawn
-      -#   .row
-      -#     .col-md-4
-      -#       = render 'donut_chart', title: 'Event types',
-      -#         combined_data: @event_type_distribution_withdrawn
-      -#     .col-md-4
-      -#       = render 'donut_chart', title: 'Difficulty levels',
-      -#         combined_data: @difficulty_levels_distribution_withdrawn
-      -#     .col-md-4
-      -#       = render 'donut_chart', title: 'Tracks',
-      -#         combined_data: @tracks_distribution_withdrawn
+        .row
+          .col-md-4
+            = render 'donut_chart', title: 'Event types',
+              combined_data: @event_type_distribution_confirmed
+          .col-md-4
+            = render 'donut_chart', title: 'Difficulty levels',
+              combined_data: @difficulty_levels_distribution_confirmed
+          .col-md-4
+            = render 'donut_chart', title: 'Tracks',
+              combined_data: @tracks_distribution_confirmed
+      .tab-pane#distribution_withdrawn
+        .row
+          .col-md-4
+            = render 'donut_chart', title: 'Event types',
+              combined_data: @event_type_distribution_withdrawn
+          .col-md-4
+            = render 'donut_chart', title: 'Difficulty levels',
+              combined_data: @difficulty_levels_distribution_withdrawn
+          .col-md-4
+            = render 'donut_chart', title: 'Tracks',
+              combined_data: @tracks_distribution_withdrawn
 
 .row
   .col-md-8

--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -67,21 +67,7 @@
             -#
               = render 'donut_chart', title: 'Tracks',
                 combined_data: @tracks_distribution
-      .tab-pane#distribution_confirmed
-        .row
-          .col-md-4
-            -#
-              = render 'donut_chart', title: 'Event types',
-                combined_data: @event_type_distribution_confirmed
-          .col-md-4
-            -#
-              = render 'donut_chart', title: 'Difficulty levels',
-                combined_data: @difficulty_levels_distribution_confirmed
-          .col-md-4
-            -#
-              = render 'donut_chart', title: 'Tracks',
-                combined_data: @tracks_distribution_confirmed
-      .tab-pane#distribution_withdrawn
+      -# .tab-pane#distribution_withdrawn
         .row
           .col-md-4
             = render 'donut_chart', title: 'Event types',
@@ -103,17 +89,6 @@
           .col-md-4
             = render 'donut_chart', title: 'Tracks',
               combined_data: @tracks_distribution_confirmed
-      .tab-pane#distribution_withdrawn
-        .row
-          .col-md-4
-            = render 'donut_chart', title: 'Event types',
-              combined_data: @event_type_distribution_withdrawn
-          .col-md-4
-            = render 'donut_chart', title: 'Difficulty levels',
-              combined_data: @difficulty_levels_distribution_withdrawn
-          .col-md-4
-            = render 'donut_chart', title: 'Tracks',
-              combined_data: @tracks_distribution_withdrawn
 
 .row
   .col-md-8

--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -3,16 +3,16 @@
   Dashboard for #{@conference.title}
 %hr
 .row
-  .col-sm-3
+  .col-sm-3.col-xs-6
     = render "big_statistic",
       icon: "user", subtitle: "Registration", value: @total_reg, delta: @new_reg
-  .col-sm-3
+  .col-sm-3.col-xs-6
     = render "big_statistic",
       icon: "check-square", subtitle: "Submission", value: @total_submissions, delta: @new_submissions
-  .col-sm-3
+  .col-sm-3.col-xs-6
     = render "big_statistic",
       icon: "file-text", subtitle: "Hour", value: @program_length, delta: @new_program_length
-  .col-sm-3
+  .col-sm-3.col-xs-6
     = render "big_statistic",
       icon: "archive", subtitle: "Withdrawn", value: @total_withdrawn, delta: @new_withdrawn
 

--- a/app/views/admin/conferences/show.html.haml
+++ b/app/views/admin/conferences/show.html.haml
@@ -60,11 +60,9 @@
             = render 'donut_chart', title: 'Event types',
               combined_data: @event_type_distribution
           .col-md-4
-            -#
               = render 'donut_chart', title: 'Difficulty levels',
                 combined_data: @difficulty_levels_distribution
           .col-md-4
-            -#
               = render 'donut_chart', title: 'Tracks',
                 combined_data: @tracks_distribution
       -# .tab-pane#distribution_withdrawn

--- a/app/views/application/_big_statistic.haml
+++ b/app/views/application/_big_statistic.haml
@@ -1,13 +1,12 @@
 - reverse ||= false
 - variant = variant_from_delta(delta, reverse: reverse)
-.dashbox.text-center
-  %span.fa
-    = fa_icon(icon)
-    = value
-  %p.text-nowrap
-    %small
+.dashbox.panel.panel-primary
+  .paenl-body.text-center
+    %span.fa
+      = fa_icon(icon)
+      = value
+    %p
       = subtitle.pluralize(value)
-      %span.label{ class: "label-#{variant}" }
-        = delta
-        since you last logged in
-
+      .label{ class: "label-#{variant}" }
+        = delta || 0
+        since last log in

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -11,7 +11,7 @@
             = f.input :password
             - if devise_mapping.rememberable?
               %p.text-right.small
-                = f.label 'Remember me'
+                = f.label 'Remember me', for: 'user_remember_me'
                 = f.check_box :remember_me
             %p.text-right
               = f.action :submit, as: :button, label: 'Sign In', button_html: {class: 'btn btn-success'}

--- a/app/views/mailbot/ticket_confirmation_template.html.erb
+++ b/app/views/mailbot/ticket_confirmation_template.html.erb
@@ -4,11 +4,11 @@
         Dear <%= @user.name %>,
 
         Thanks! You have successfully booked <%= @ticket_purchase.quantity %> <%= @ticket_purchase.ticket.title %> ticket(s) for the event <%= @conference.title %>. Your transaction id is <%= @ticket_purchase.id %>.
-        
+
         Please, find the ticket(s) pdf attached.
-        
+
         Best wishes,
-        <%= @conference.title %> Team    
+        <%= @conference.title %> Team
     </span>
   </div>
 <%= render partial: "layouts/mailbot_footer" %>

--- a/app/views/proposals/_encouragement_text.html.haml
+++ b/app/views/proposals/_encouragement_text.html.haml
@@ -17,6 +17,7 @@
     %b.notranslate= pluralize(@program.cfp.remaining_days, 'day')
     left!
     %span.notranslate= @conference.title
-    will only be as good as the content you present. Submit early, submit often!
+    will only be as good as the content you present.
+    %br Submit early, submit often!
   - else
     The submission period is closed now.

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -25,7 +25,7 @@
         %span{ class: 'help-block select-help-text collapse event_difficulty_level_id', id: "#{difficulty_level.id}-help" }
           = difficulty_level.description
 
-    = render 'submission_type_content_form', f: f, program: @program
+    = render 'proposals/submission_type_content_form', f: f, program: @program
 
     - if @program.cfp&.enable_registrations?
       = f.inputs 'Enable pre-registration' do

--- a/app/views/proposals/_proposal_form.html.haml
+++ b/app/views/proposals/_proposal_form.html.haml
@@ -11,72 +11,27 @@
 
     = track_selector_input f
 
-    = f.input :event_type_id, as: :select,
-      collection: @conference.program.event_types.map {|type| ["#{type.title} - #{show_time(type.length)}", type.id,
-      data: { min_words: type.minimum_abstract_length, max_words: type.maximum_abstract_length, help: type.description }]},
-      include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' }
-
     - if @program.languages.present?
       = f.input :language, as: :select,
         collection: @languages,
         include_blank: false, label: 'Language', input_html: { class: 'select-help-toggle' }
 
-    - @conference.program.event_types.each do |event_type|
-      %span{ class: 'help-block select-help-text event_event_type_id collapse', id: "#{event_type.id}-help" }
-        = event_type.description
+    - if @program.difficulty_levels.present?
+      = f.input :difficulty_level, as: :select, collection: @program.difficulty_levels,
+        input_html: { class: 'select-help-toggle' },
+        include_blank: '(Please select)' if @conference.program.difficulty_levels.any?
 
-    = f.input :difficulty_level, as: :select, collection: @conference.program.difficulty_levels, input_html: { class: 'select-help-toggle' },
-      include_blank: '(Please select)' if @conference.program.difficulty_levels.any?
+      - @program.difficulty_levels.each do |difficulty_level|
+        %span{ class: 'help-block select-help-text collapse event_difficulty_level_id', id: "#{difficulty_level.id}-help" }
+          = difficulty_level.description
 
-    - @conference.program.difficulty_levels.each do |difficulty_level|
-      %span{ class: 'help-block select-help-text collapse event_difficulty_level_id', id: "#{difficulty_level.id}-help" }
-        = difficulty_level.description
+    = render 'submission_type_content_form', f: f, program: @program
 
-    = f.input :abstract, required: true, input_html: { rows: 5, data: { provide: 'markdown' } },
-      hint: markdown_hint('[Tips to improve your presentations.](http://blog.hubspot.com/blog/tabid/6307/bid/5975/10-Rules-to-Instantly-Improve-Your-Presentations.aspx)')
-
-    %p
-      You have used
-      %span#abstract-count #{@event.abstract_word_count}
-      words.  Abstracts must be between
-      %span#abstract-minimum-word-count
-        0
-      and
-      %span#abstract-maximum-word-count
-        250
-      words.
-
-    %br
-    - @conference.program.event_types.each do |event_type|
-      %span{ class: 'help-block select-help-text event_event_type_id collapse', id: "#{event_type.id}-help" }
-        %h3
-          = event_type.name
-          Instructions
-        = markdown(event_type.submission_instructions)
-
-    = f.input :submission_text, input_html: { rows: 5, data: { provide: 'markdown' }, placeholder: '' },
-      hint: markdown_hint('Only conference organizers will read this.')
-    %button.btn.btn-primary.primary-button{ type: 'button', id: 'sub_text_reset', data: { confirm: 'Do you really want to reset your submission text to the provided template?' } } Reset to Template
-
-    %p
-      You have used
-      %span#submission-count #{@event.submission_word_count}
-      words.  Submission descriptions must be between
-      %span#submission-minimum-word-count
-        0
-      and
-      %span#submission-maximum-word-count
-        250
-      words.
-
-    - if current_user.is_admin? or @program.cfp&.enable_registrations?
+    - if @program.cfp&.enable_registrations?
       = f.inputs 'Enable pre-registration' do
         = f.input :require_registration, label: 'Require participants to register to your event'
         - message = @event.room ? "Value must be between 1 and #{@event.room.size}" : 'Check room capacity after scheduling.'
         = f.input :max_attendees, hint: 'The maximum number of participants. ' + message
-
-    - if current_user.has_any_role? :admin, { name: :organizer, resource: @conference }, { name: :cfp, resource: @conference }
-      = f.input :is_highlight
 
     %p.text-right
       = link_to '#description', 'data-toggle' => 'collapse' do
@@ -84,12 +39,15 @@
     #description{ class: "collapse #{ 'in' if @event.description.present? }" }
       = f.input :description, input_html: { rows: 5 }, label: 'Requirements', placeholder: 'Eg. Whiteboard, printer, or something like that.'
 
+    - if current_user.has_any_role? :admin, { name: :organizer, resource: @conference }, { name: :cfp, resource: @conference }
+      %p (Admin Only)
+      = f.input :is_highlight
 
   %p.text-right
     - if @event.new_record?
       = f.submit 'Submit Proposal', class: 'btn btn-success'
     - else
-      = f.submit 'Update Proposal', class: 'btn btn-success'
+      = f.submit 'Update Proposal', class: 'btn btn-primary'
 
 :javascript
   $(document).ready(function() {

--- a/app/views/proposals/_submission_type_content_form.haml
+++ b/app/views/proposals/_submission_type_content_form.haml
@@ -56,7 +56,7 @@
         .panel-body
           = markdown(event_type.submission_instructions)
         .panel-footer
-          %button.btn.btn-warning.btn-xs{ type: 'button', id: 'sub_text_reset', data: { confirm: 'Do you really want to reset your submission text to the provided template?' } }
+          %button.btn.btn-warning.btn-xs.js-resetSubmissionText{ type: 'button', data: { confirm: 'Do you really want to reset your submission text to the provided template?' } }
             Reset Submission to Template
           %span.small You may want to use this if you have changed the submission type.
 

--- a/app/views/proposals/_submission_type_content_form.haml
+++ b/app/views/proposals/_submission_type_content_form.haml
@@ -1,0 +1,66 @@
+-# PARTIAL FOR EVENT/PROPOSAL FORM
+-# `f` a current from helper.
+
+= f.input :event_type_id, as: :select, include_blank: false, label: 'Type',
+  input_html: { class: 'select-help-toggle' },
+  collection: event_type_options(program.event_types)
+
+
+- program.event_types.each do |event_type|
+  .help-block.event_event_type_id.collapse{ id: "#{event_type.id}-help" }
+    %strong Description
+    %div
+      = markdown(event_type.description)
+
+%h3 Submission Abstract
+%p
+  The abstract is reviewed by the committee and included in the conference program.
+  You are encouraged to include links or other references as appropriate.
+
+= f.label :abstract, class: 'sr-only'
+= f.input :abstract, required: true, label: false,
+  input_html: { rows: 5, data: { provide: 'markdown' } },
+  hint: markdown_hint
+
+%p
+  You have used
+  %span#abstract-count #{@event.abstract_word_count}
+  words. Abstracts must be between
+  %span#abstract-minimum-word-count 0
+  and
+  %span#abstract-maximum-word-count 250
+  words.
+
+%hr
+%h3 Submission Details
+%p
+  This part of the submission is intended only for the conference committee.
+
+- program.event_types.each do |event_type|
+  .help-block.select-help-text.event_event_type_id.collapse{ id: "#{event_type.id}-instructions" }
+    - if event_type.submission_instructions.blank?
+      %p
+        Use this space to include any additional inforrmation that is helpful in reviewing your
+        submission. If you have any co-presenters, please include them
+        below. After submission, you will have the opportunity to add them to the
+        speakers list. (However, they must have an active #{ENV['OSEM_NAME']} account.)
+    - else
+      %p
+        Please use the following as the template for your submission. This will help the conference committee review your submission with all the details they need. If you have any co-presenters, please include them below. After
+        submission, you will have the opportunity to add them to the speakers
+        list. (However, they must have an active #{ENV['OSEM_NAME']} account.)
+      .panel.panel-primary
+        .panel-heading
+          = event_type.name
+          Template
+        .panel-body
+          = markdown(event_type.submission_instructions)
+        .panel-footer
+          %button.btn.btn-warning.btn-xs{ type: 'button', id: 'sub_text_reset', data: { confirm: 'Do you really want to reset your submission text to the provided template?' } }
+            Reset Submission to Template
+          %span.small You may want to use this if you have changed the submission type.
+
+= f.label :submission_text, class: 'sr-only'
+= f.input :submission_text, label: false,
+  input_html: { rows: 10, data: { provide: 'markdown' } },
+  hint: markdown_hint

--- a/app/views/proposals/_submission_type_content_form.haml
+++ b/app/views/proposals/_submission_type_content_form.haml
@@ -1,5 +1,4 @@
 -# PARTIAL FOR EVENT/PROPOSAL FORM
--# `f` a current from helper.
 
 = f.input :event_type_id, as: :select, include_blank: false, label: 'Type',
   input_html: { class: 'select-help-toggle' },
@@ -24,7 +23,7 @@
 
 %p
   You have used
-  %span#abstract-count #{@event.abstract_word_count}
+  %span#abstract-count 0
   words. Abstracts must be between
   %span#abstract-minimum-word-count 0
   and
@@ -46,9 +45,11 @@
         speakers list. (However, they must have an active #{ENV['OSEM_NAME']} account.)
     - else
       %p
-        Please use the following as the template for your submission. This will help the conference committee review your submission with all the details they need. If you have any co-presenters, please include them below. After
-        submission, you will have the opportunity to add them to the speakers
-        list. (However, they must have an active #{ENV['OSEM_NAME']} account.)
+        Please use the following as the template for your submission. This will help the conference
+        committee review your submission with all the details they need. If you have any
+        co-presenters, please include them below. After submission, you will have the opportunity
+        to add them to the speakers list. (However, they must have an active #{ENV['OSEM_NAME']}
+        account.)
       .panel.panel-primary
         .panel-heading
           = event_type.name
@@ -56,7 +57,8 @@
         .panel-body
           = markdown(event_type.submission_instructions)
         .panel-footer
-          %button.btn.btn-warning.btn-xs.js-resetSubmissionText{ type: 'button', data: { confirm: 'Do you really want to reset your submission text to the provided template?' } }
+          %button.btn.btn-warning.btn-xs.js-resetSubmissionText{ type: 'button',
+            data: { confirm: 'Do you really want to reset your submission text to the provided template?' } }
             Reset Submission to Template
           %span.small You may want to use this if you have changed the submission type.
 

--- a/app/views/proposals/_tooltip.html.haml
+++ b/app/views/proposals/_tooltip.html.haml
@@ -25,6 +25,7 @@
     %li{'class'=>class_for_todo(progress_status['track'])}
       %span{'class'=>icon_for_todo(progress_status['track'])}
         = link_to 'Add a track', edit_conference_program_proposal_path(event.program.conference.short_title, event)
-  %li{'class'=>class_for_todo(progress_status['difficulty_level'])}
-    %span{'class'=>icon_for_todo(progress_status['difficulty_level'])}
-      = link_to 'Add a difficulty level', edit_conference_program_proposal_path(event.program.conference.short_title, event)
+  - unless progress_status[:difficulty_level].nil?
+    %li{'class'=>class_for_todo(progress_status['difficulty_level'])}
+      %span{'class'=>icon_for_todo(progress_status['difficulty_level'])}
+        = link_to 'Add a difficulty level', edit_conference_program_proposal_path(event.program.conference.short_title, event)

--- a/app/views/proposals/_tooltip.html.haml
+++ b/app/views/proposals/_tooltip.html.haml
@@ -1,31 +1,31 @@
 - progress_status = event.progress_status
 %ul.list-unstyled
   - if can? :create, @conference.registrations.new
-    %li{'class'=>class_for_todo(progress_status['registered'])}
-      %span{'class'=>icon_for_todo(progress_status['registered'])}
-        - if progress_status['registered']
+    %li{class: class_for_todo(progress_status[:registered])}
+      %span{class: icon_for_todo(progress_status[:registered])}
+        - if progress_status[:registered]
           Speaker(s) registered to the conference
         - else
           = link_to 'Speaker(s) not registered to the conference', new_conference_conference_registration_path(event.program.conference.short_title)
-  %li{'class'=>class_for_todo(progress_status['biographies'])}
-    %span{'class'=>icon_for_todo(progress_status['biographies'])}
-      - if progress_status['biographies']
+  %li{class: class_for_todo(progress_status[:biographies])}
+    %span{class: icon_for_todo(progress_status[:biographies])}
+      - if progress_status[:biographies]
         Speakers have filled out their biographies
       - elsif current_user.biography.blank? && event.speakers.include?(current_user)
         = link_to 'Fill out your biography', edit_user_path(current_user)
       - else
         Speakers' biographies missing
-  %li{'class'=>class_for_todo(progress_status['subtitle'])}
-    %span{'class'=>icon_for_todo(progress_status['subtitle'])}
+  %li{class: class_for_todo(progress_status[:subtitle])}
+    %span{class: icon_for_todo(progress_status[:subtitle])}
       = link_to 'Add a subtitle', edit_conference_program_proposal_path(event.program.conference.short_title, event)
-  %li{'class'=>class_for_todo(progress_status['commercials'])}
-    %span{'class'=>icon_for_todo(progress_status['commercials'])}
+  %li{class: class_for_todo(progress_status[:commercials])}
+    %span{class: icon_for_todo(progress_status[:commercials])}
       = link_to 'Add materials', edit_conference_program_proposal_path(event.program.conference.short_title, event, anchor: 'commercials-content')
-  - unless progress_status['track'].nil?
-    %li{'class'=>class_for_todo(progress_status['track'])}
-      %span{'class'=>icon_for_todo(progress_status['track'])}
+  - unless progress_status[:track].nil?
+    %li{class: class_for_todo(progress_status[:track])}
+      %span{class: icon_for_todo(progress_status[:track])}
         = link_to 'Add a track', edit_conference_program_proposal_path(event.program.conference.short_title, event)
   - unless progress_status[:difficulty_level].nil?
-    %li{'class'=>class_for_todo(progress_status['difficulty_level'])}
-      %span{'class'=>icon_for_todo(progress_status['difficulty_level'])}
+    %li{class: class_for_todo(progress_status[:difficulty_level])}
+      %span{class: icon_for_todo(progress_status[:difficulty_level])}
         = link_to 'Add a difficulty level', edit_conference_program_proposal_path(event.program.conference.short_title, event)

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -5,6 +5,7 @@
         %h1 New #{@conference.title} Proposal
   - if @program.cfp_open?
     - if @program.cfp.description.present?
+      %h2 Call for Proposals
       .row
         .col-md-12
           = markdown(@program.cfp.description, escape_html=false)
@@ -43,41 +44,61 @@
                 include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' }
 
               - @program.event_types.each do |event_type|
-                %div{ class: 'help-block event_event_type_id collapse', id: "#{event_type.id}-help"}
+                .help-block.event_event_type_id.collapse{ id: "#{event_type.id}-help" }
                   %strong Description
                   %div
                     = markdown(event_type.description)
 
-              = f.input :abstract, required: true, input_html: { rows: 5, data: { provide: 'markdown' } },
-                hint: markdown_hint
+              %h3 Submission Abstract
+              %p
+                The abstract is reviewed by the committee and included in the conference program.
+                You are encouraged to include links or other references as appropriate.
 
+              = f.label :abstract, class: 'sr-only'
+              = f.input :abstract, required: true, label: false,
+                        input_html: { rows: 5, data: { provide: 'markdown' } },
+                        hint: markdown_hint
               %p
                 You have used
                 %span#abstract-count #{@event.abstract_word_count}
                 words. Abstracts must be between
-                %span#abstract-minimum-word-count
-                  0
+                %span#abstract-minimum-word-count 0
                 and
-                %span#abstract-maximum-word-count
-                  250
+                %span#abstract-maximum-word-count 250
                 words.
 
-              %br
+              %hr
+              %h3
+                Submission Details
+              %p
+                This part of the submission is intended only for the conference committee.
+
               - @conference.program.event_types.each do |event_type|
-                %span{ class: 'help-block select-help-text event_event_type_id collapse', id: "#{event_type.id}-instructions" }
-                  %h3
-                    = event_type.name
-                    Instructions
-                  %p Please use this as the template for your submission.
-                  This part of the submission is intended only for the conference committee.
-                  %hr
-                  = markdown(event_type.submission_instructions)
+                .help-block.select-help-text.event_event_type_id.collapse{ id: "#{event_type.id}-instructions" }
+                  - if event_type.submission_instructions.blank?
+                    Use this space to include any additional inforrmation that is helpful in reviewing your submission. If you have any co-presenters, please include them
+                    below. After submission, you will have the opportunity to add them to the
+                    speakers list. (However, they must have an active #{ENV['OSEM_NAME']} account.)
+                  - else
+                    %p
+                      Please use the following as the template for your submission. This will help the conference committee review your submission with all the details they need. If you have any co-presenters, please include them below. After
+                      submission, you will have the opportunity to add them to the speakers
+                      list. (However, they must have an active #{ENV['OSEM_NAME']} account.)
+                    .panel.panel-primary
+                      .panel-heading
+                        = event_type.name
+                        Template
+                      .panel-body
+                        = markdown(event_type.submission_instructions)
+                      .panel-footer
+                        %button.btn.btn-warning.btn-xs{ type: 'button', id: 'sub_text_reset', data: { confirm: 'Do you really want to reset your submission text to the provided template?' } } Reset Submission to Template
+                        %span.small
+                          You may want to use this if you have changed the submission type.
 
-
-              = f.input :submission_text, input_html: { rows: 5, data: { provide: 'markdown' } },
-                hint: markdown_hint
-
-              %button.btn.btn-primary.primary-button{ type: 'button', id: 'sub_text_reset', data: { confirm: 'Do you really want to reset your submission text to the provided template?' } } Reset to Template
+              = f.label :submission_text, class: 'sr-only'
+              = f.input :submission_text, label: false,
+                        input_html: { rows: 10, data: { provide: 'markdown' } },
+                        hint: markdown_hint
 
               - if @program.cfp.enable_registrations?
                 = f.input :require_registration, label: 'Require participants to register to your event'
@@ -90,7 +111,7 @@
                 = f.input :description, input_html: { rows: 5 }, label: 'Requirements', placeholder: 'Eg. Whiteboard, printer, or something like that.'
 
             %p.text-right
-              = f.submit 'Submit Proposal', class: 'btn btn-success'
+              = f.submit 'Submit Proposal', class: 'btn btn-success btn-lg'
 
         .tab-pane{role: 'tabpanel', id: 'signin'}
           = render partial: 'devise/shared/sign_in_form_embedded'

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -38,67 +38,16 @@
                   collection: @languages,
                   include_blank: false, label: 'Language', input_html: { class: 'select-help-toggle' }
 
-              = f.input :event_type_id, as: :select,
-                collection: @program.event_types.map {|type| ["#{type.title} - #{show_time(type.length)}", type.id,
-                data: { min_words: type.minimum_abstract_length, max_words: type.maximum_abstract_length, instructions: type.submission_instructions }]},
-                include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' }
+              - if @program.difficulty_levels.present?
+                = f.input :difficulty_level, as: :select, collection: @program.difficulty_levels,
+                  input_html: { class: 'select-help-toggle' },
+                  include_blank: '(Please select)' if @conference.program.difficulty_levels.any?
 
-              - @program.event_types.each do |event_type|
-                .help-block.event_event_type_id.collapse{ id: "#{event_type.id}-help" }
-                  %strong Description
-                  %div
-                    = markdown(event_type.description)
+                - @program.difficulty_levels.each do |difficulty_level|
+                  %span.help-block.select-help-text.collapse.event_difficulty_level_id{ id: "#{difficulty_level.id}-help" }
+                    = difficulty_level.description
 
-              %h3 Submission Abstract
-              %p
-                The abstract is reviewed by the committee and included in the conference program.
-                You are encouraged to include links or other references as appropriate.
-
-              = f.label :abstract, class: 'sr-only'
-              = f.input :abstract, required: true, label: false,
-                        input_html: { rows: 5, data: { provide: 'markdown' } },
-                        hint: markdown_hint
-              %p
-                You have used
-                %span#abstract-count #{@event.abstract_word_count}
-                words. Abstracts must be between
-                %span#abstract-minimum-word-count 0
-                and
-                %span#abstract-maximum-word-count 250
-                words.
-
-              %hr
-              %h3
-                Submission Details
-              %p
-                This part of the submission is intended only for the conference committee.
-
-              - @conference.program.event_types.each do |event_type|
-                .help-block.select-help-text.event_event_type_id.collapse{ id: "#{event_type.id}-instructions" }
-                  - if event_type.submission_instructions.blank?
-                    Use this space to include any additional inforrmation that is helpful in reviewing your submission. If you have any co-presenters, please include them
-                    below. After submission, you will have the opportunity to add them to the
-                    speakers list. (However, they must have an active #{ENV['OSEM_NAME']} account.)
-                  - else
-                    %p
-                      Please use the following as the template for your submission. This will help the conference committee review your submission with all the details they need. If you have any co-presenters, please include them below. After
-                      submission, you will have the opportunity to add them to the speakers
-                      list. (However, they must have an active #{ENV['OSEM_NAME']} account.)
-                    .panel.panel-primary
-                      .panel-heading
-                        = event_type.name
-                        Template
-                      .panel-body
-                        = markdown(event_type.submission_instructions)
-                      .panel-footer
-                        %button.btn.btn-warning.btn-xs{ type: 'button', id: 'sub_text_reset', data: { confirm: 'Do you really want to reset your submission text to the provided template?' } } Reset Submission to Template
-                        %span.small
-                          You may want to use this if you have changed the submission type.
-
-              = f.label :submission_text, class: 'sr-only'
-              = f.input :submission_text, label: false,
-                        input_html: { rows: 10, data: { provide: 'markdown' } },
-                        hint: markdown_hint
+              = render 'submission_type_content_form', f: f, program: @program
 
               - if @program.cfp.enable_registrations?
                 = f.input :require_registration, label: 'Require participants to register to your event'

--- a/app/views/proposals/new.html.haml
+++ b/app/views/proposals/new.html.haml
@@ -31,19 +31,20 @@
 
             = f.inputs name: 'Proposal Information' do
               = f.input :title, as: :string, required: true, input_html: { required: true }
-              = f.input :event_type_id, as: :select,
-                collection: @program.event_types.map {|type| ["#{type.title} - #{show_time(type.length)}", type.id,
-                data: { min_words: type.minimum_abstract_length, max_words: type.maximum_abstract_length, help: type.description }]},
-                include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' }
 
               - if @program.languages.present?
                 = f.input :language, as: :select,
                   collection: @languages,
                   include_blank: false, label: 'Language', input_html: { class: 'select-help-toggle' }
 
+              = f.input :event_type_id, as: :select,
+                collection: @program.event_types.map {|type| ["#{type.title} - #{show_time(type.length)}", type.id,
+                data: { min_words: type.minimum_abstract_length, max_words: type.maximum_abstract_length, instructions: type.submission_instructions }]},
+                include_blank: false, label: 'Type', input_html: { class: 'select-help-toggle' }
+
               - @program.event_types.each do |event_type|
                 %div{ class: 'help-block event_event_type_id collapse', id: "#{event_type.id}-help"}
-                  %strong Directions
+                  %strong Description
                   %div
                     = markdown(event_type.description)
 
@@ -63,7 +64,7 @@
 
               %br
               - @conference.program.event_types.each do |event_type|
-                %span{ class: 'help-block select-help-text event_event_type_id collapse', id: "#{event_type.id}-help" }
+                %span{ class: 'help-block select-help-text event_event_type_id collapse', id: "#{event_type.id}-instructions" }
                   %h3
                     = event_type.name
                     Instructions

--- a/app/views/schedules/happening_now.haml
+++ b/app/views/schedules/happening_now.haml
@@ -9,10 +9,12 @@
     .col-md-12
       %h2
         #{pluralize(@events_schedules.count, 'Event')} Occurring Within The Next 30 minutes.
+        %br
         %small
           This page was loaded at
           = inyourtz(Time.now) do
-            #{Time.now.strftime('%a %b %d at %I:%M %P (%z)')}
+            = Time.now.strftime('%a %b %d at %I:%M %P (%z)')
+          \.
 
   .row
     / TODO: Clean this up, merge with all events page.
@@ -26,7 +28,7 @@
               = inyourtz(event_schedule.start_time, @conference.timezone) do
                 = date = event_schedule.start_time.strftime('%Y-%m-%d')
             %a.pull-right{ title: 'Go up', href: '#program' }
-              %i.fa.fa-angle-double-up.fa-lg{ 'aria-hidden': true }
+              %i.fa.fa-angle-double-up.fa-lg{ 'aria-hidden' => true }
       - if event_schedule.start_time.strftime('%H:%M').eql?(time)
         .col-xs-12.col-md-11.col-md-offset-1
           = render 'event', event: event_schedule.event, event_schedule: event_schedule

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -195,7 +195,7 @@ feature Event do
     scenario 'can reset to text template', feature: true, js: true do
       event_type = conference.program.event_types[-1]
       event_type.description = 'Example event description'
-      event_type.submisson_instructions = '## Fill Me In!'
+      event_type.submission_instructions = '## Fill Me In!'
       event_type.save!
 
       sign_in participant

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -195,6 +195,7 @@ feature Event do
     scenario 'can reset to text template', feature: true, js: true do
       event_type = conference.program.event_types[-1]
       event_type.description = 'Example event description'
+      event_type.submisson_instructions = '## Fill Me In!'
       event_type.save!
 
       sign_in participant
@@ -208,7 +209,7 @@ feature Event do
         click_button 'Reset to Template'
       end
 
-      expect(page.find('#event_submission_text').value).to eq(event_type.description)
+      expect(page.find('#event_submission_text').value).to eq(event_type.submisson_instructions)
     end
   end
 end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -209,7 +209,7 @@ feature Event do
         click_button 'Reset Submission to Template'
       end
 
-      expect(page.find('#event_submission_text').value).to eq(event_type.submisson_instructions)
+      expect(page.find('#event_submission_text').value).to eq(event_type.submission_instructions)
     end
   end
 end

--- a/spec/features/proposals_spec.rb
+++ b/spec/features/proposals_spec.rb
@@ -206,7 +206,7 @@ feature Event do
       fill_in 'event_submission_text', with: 'Lorem ipsum example submission text'
 
       accept_confirm do
-        click_button 'Reset to Template'
+        click_button 'Reset Submission to Template'
       end
 
       expect(page.find('#event_submission_text').value).to eq(event_type.submisson_instructions)


### PR DESCRIPTION
- [X] Use the term "Directions" on the new proposal page.
- [x] Update the top new proposal copy to clarify flow
- [X] fill submission text from instructions
- [x] render emails sent as html
- [x] make the CSS textbox monospace
- [ ] display "reviewer comments"
- [x] fix the remember me checkbox label

## New Proposal Page
![Snap!Con New Proposal](https://user-images.githubusercontent.com/1505907/112261640-80f4b280-8c29-11eb-8c9a-e84528f4fd06.png)

## Cleaned Up Dashboard
<img width="1591" alt="Screen Shot 2021-03-23 at 5 17 04 PM" src="https://user-images.githubusercontent.com/1505907/112261666-8b16b100-8c29-11eb-87b0-9e030db3600c.png">
