### PR TITLE
Use Hosted Stripe Checkout, Support Multiple Currencies

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -6,40 +6,51 @@ class PaymentsController < ApplicationController
   load_resource :conference, find_by: :short_title
   authorize_resource :conference_registrations, class: Registration
 
-  def index
-    @payments = current_user.payments
-  end
-
   def new
     @total_amount_to_pay = Ticket.total_price(@conference, current_user, paid: false)
     if @total_amount_to_pay.zero?
       raise CanCan::AccessDenied.new('Nothing to pay for!', :new, Payment)
     end
 
-    @has_registration_ticket = params[:has_registration_ticket]
     @unpaid_ticket_purchases = current_user.ticket_purchases.unpaid.by_conference(@conference)
   end
 
   def create
-    @payment = Payment.new payment_params
+    @payment = Payment.new(payment_params)
+    checkout_session = create_stripe_checkout(unpaid_tickets_for_user)
 
-    if @payment.purchase && @payment.save
-      update_purchased_ticket_purchases
+    @payment.amount = @payment.amount_to_pay
 
-      has_registration_ticket = params[:has_registration_ticket]
-      if has_registration_ticket == 'true'
-        redirect_to new_conference_conference_registration_path(@conference.short_title),
-                    notice: 'Thanks! Your ticket is booked successfully. Please register for the conference.'
-      else
-        redirect_to conference_physical_tickets_path,
-                    notice: 'Thanks! Your ticket is booked successfully.'
-      end
+    if checkout_session.url
+      @payment.authorization_code = session.id
+      @payment.status = :pending
+      @payment.save
+      redirect_to checkout_session.url, status: 303
     else
-      @total_amount_to_pay = Ticket.total_price(@conference, current_user, paid: false)
-      @unpaid_ticket_purchases = current_user.ticket_purchases.unpaid.by_conference(@conference)
-      flash.now[:error] = @payment.errors.full_messages.to_sentence + ' Please try again with correct credentials.'
-      render :new
+      @payment.status = :failure
+      @payment.save
+      flash[:error] = "#{@payment.errors&.full_messages.to_sentence} Please try again with correct credentials."
+      redirect_to new_conference_payment_path(@conference)
     end
+  end
+
+  def success
+    @payment = Payment.find_by(authorization_code: params[:session_id])
+    update_purchased_ticket_purchases
+
+    has_registration_ticket = current_user.tickets.for_registration(@conference).present?
+    if has_registration_ticket
+      redirect_to new_conference_conference_registration_path(@conference.short_title),
+                  notice: 'Thanks! Your ticket is booked successfully. Please register for the conference.'
+    else
+      redirect_to conference_physical_tickets_path,
+                  notice: 'Thanks! Your ticket is booked successfully.'
+    end
+  end
+
+  def cancel
+    unpaid_tickets_for_user.destroy_all
+    flash[:notice] = 'Your payment has been cancelled.'
   end
 
   private
@@ -51,8 +62,33 @@ class PaymentsController < ApplicationController
                  user: current_user, conference: @conference)
   end
 
+  def create_stripe_checkout(ticket_purchases)
+    methods = %w|card|
+    if euro_currency?
+      methods << %w|sepa_debit|
+    end
+    puts "STRIPE METHODS #{methods}"
+    puts ticket_purchases.map(&:ticket).map(&:price_currency)
+    Stripe::Checkout::Session.create(
+      payment_method_types: methods,
+      line_items:           ticket_purchases.map(&:stripe_line_item),
+      mode:                 'payment',
+      success_url:          "#{success_conference_payments_url(@conference.short_title)}?session_id={CHECKOUT_SESSION_ID}",
+      cancel_url:           "#{cancel_conference_payments_url(@conference.short_title)}?session_id={CHECKOUT_SESSION_ID}",
+    )
+  end
+
+  def euro_currency?
+    unpaid_tickets_for_user.map(&:ticket).all? { |t| t.price_currency == 'EUR' }
+  end
+
+  def unpaid_tickets_for_user
+    @unpaid_tickets_for_user ||= current_user.ticket_purchases.by_conference(@conference).unpaid
+  end
+
   def update_purchased_ticket_purchases
-    current_user.ticket_purchases.by_conference(@conference).unpaid.each do |ticket_purchase|
+    # REFACTOR: Move to method on Payment
+    unpaid_tickets_for_user.each do |ticket_purchase|
       ticket_purchase.pay(@payment)
     end
   end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -14,6 +14,7 @@
 #  conference_id      :integer          not null
 #  user_id            :integer          not null
 #
+
 class Payment < ApplicationRecord
   has_many :ticket_purchases
   belongs_to :user
@@ -29,7 +30,8 @@ class Payment < ApplicationRecord
   enum status: {
     unpaid:  0,
     success: 1,
-    failure: 2
+    failure: 2,
+    pending: 3
   }
 
   def amount_to_pay
@@ -37,7 +39,6 @@ class Payment < ApplicationRecord
   end
 
   def stripe_description
-    # "ticket purchases(#{user.username})"
     "Tickets for #{conference.title} #{user.name} #{user.email}"
   end
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -79,7 +79,7 @@ class Ticket < ApplicationRecord
 
   def self.total_price_user(conference, user, paid: false)
     tickets = TicketPurchase.where(conference: conference, user: user, paid: paid)
-    tickets.inject(0){ |sum, ticket| sum + (ticket.amount_paid * ticket.quantity) }
+    tickets.inject(0) { |sum, ticket| sum + (ticket.amount_paid * ticket.quantity) }
   end
 
   def tickets_turnover_total(id)
@@ -97,6 +97,7 @@ class Ticket < ApplicationRecord
   private
 
   def tickets_of_conference_have_same_currency
+    return true
     tickets = Ticket.where(conference_id: conference_id)
     return if tickets.count.zero? || (tickets.count == 1 && self == tickets.first)
 

--- a/app/models/ticket_purchase.rb
+++ b/app/models/ticket_purchase.rb
@@ -91,6 +91,20 @@ class TicketPurchase < ApplicationRecord
     sum('amount_paid * quantity')
   end
 
+  def stripe_line_item
+    {
+      price_data: {
+        currency:     ticket.price_currency,
+        product_data: {
+          name: "#{conference.title} Ticket: #{ticket.title}",
+        },
+        unit_amount:   ticket.price_cents,
+      },
+      quantity:        quantity,
+    }
+  end
+
+  # TODO: rename paid
   def pay(payment)
     update_attributes(paid: true, payment: payment)
     PhysicalTicket.transaction do

--- a/app/views/payments/_payment.html.haml
+++ b/app/views/payments/_payment.html.haml
@@ -19,14 +19,7 @@
           %td
             = humanized_money_with_symbol ticket.quantity * ticket.price
 
-= form_tag conference_payments_path(@conference.short_title, :has_registration_ticket => @has_registration_ticket) do
-  %script.stripe-button{'src': "https://checkout.stripe.com/checkout.js",
-    'data': {amount: @total_amount_to_pay.cents,
-      label: "Pay #{humanized_money_with_symbol @total_amount_to_pay}",
-      email: current_user.email,
-      currency: @total_amount_to_pay.currency,
-      name: ENV['OSEM_NAME'] || 'OSEM',
-      description: "#{ENV['OSEM_NAME']} tickets",
-      key: ENV['STRIPE_PUBLISHABLE_KEY'] || Rails.application.secrets.stripe_publishable_key, locale: "auto"}}
+= form_tag conference_payments_path(@conference.short_title) do |f|
   = link_to('Edit Purchase', conference_tickets_path(@conference.short_title),
             class: 'btn btn-default')
+  = submit_tag 'Purcahse', type: 'submit', class: 'btn btn-success pull-right'

--- a/app/views/payments/new.html.haml
+++ b/app/views/payments/new.html.haml
@@ -10,7 +10,7 @@
     .col-md-13
       %p.text-center
         %strong
-          If you do not have a credit card, please reach out to use at
+          If you do not have a credit card, please reach out to us at
           = mail_to(@conference.contact.email)
       %hr
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -196,7 +196,12 @@ Osem::Application.routes.draw do
     resource :conference_registration, path: 'register'
     resources :tickets, only: [:index]
     resources :ticket_purchases, only: [:create, :destroy, :index]
-    resources :payments, only: [:index, :new, :create]
+    resources :payments, only: [:new, :create] do
+      collection do
+        get 'success'
+        get 'cancel'
+      end
+    end
     resources :physical_tickets, only: [:index, :show]
     resource :subscriptions, only: [:create, :destroy]
     resource :schedule, only: [:show] do


### PR DESCRIPTION
* uses the stripe checkout redirect flow
* allows _tickets_ to have multiple different currencies
* a _purchase_ now must only have one currancy
* Support additional payment methods when EUR is selected. 