### PR TITLE
Calendar: Hide Overview Button But Days = 1

### DIFF
--- a/app/assets/javascripts/fullcalendar.js.erb
+++ b/app/assets/javascripts/fullcalendar.js.erb
@@ -21,6 +21,11 @@ $( document ).ready(function() {
     let operator = localOffset < 0 ? '+' : '-';
     $('.js-localTimezone').text(`(${localName} UTC ${operator}${Math.abs(localOffset)})`);
 
+    let rightHeaderToolbar = 'resourceTimeGridDay,resourceTimeGridFourDay,listDay';
+    if (event_num_days == 1) {
+      rightHeaderToolbar = 'resourceTimeGridDay,listDay';
+    }
+
     var calendar = new FullCalendar.Calendar(calendarEl, {
       schedulerLicenseKey: license_key,
       nowIndicator: true,
@@ -60,7 +65,7 @@ $( document ).ready(function() {
       headerToolbar: {
         left: 'prev,next',
         center: 'title',
-        right: 'resourceTimeGridDay,resourceTimeGridFourDay,listDay'
+        right: rightHeaderToolbar
       },
       // TODO: Make this conference Specific?
       views: {

--- a/app/assets/javascripts/fullcalendar.js.erb
+++ b/app/assets/javascripts/fullcalendar.js.erb
@@ -3,17 +3,20 @@ $( document ).ready(function() {
     if (!calendarEl) return; //check that we need a vertical schedule
     let $fullCalendar = $('#fullcalendar');
 
-    let license_key = "<%= Rails.configuration.fullcalendar[:license_key] %>";
+    let license_key = "<%= Rails.configuration.fullcalendar[:license_key]%>";
 
     let offset = $fullCalendar.data('tzOffset');
     let interval = $fullCalendar.data('minInterval');
     let localOffset = (new Date()).getTimezoneOffset()/60;
     let startTime = $fullCalendar.data('startHour') - offset - localOffset;
     let endTime = $fullCalendar.data('endHour') - offset - localOffset;
+    let startDate = new Date($fullCalendar.data('startDate'));
+    let endDate = new Date($fullCalendar.data('endDate'));
+    let event_num_days = (endDate.getTime() - startDate.getTime())/ (1000 * 3600 * 24);
+    let width = Math.min(4, event_num_days);
     let localName = Intl.DateTimeFormat().resolvedOptions().timeZone;
     // Program Hours * Minutes / Interval * Min Row Height for an event.
     let contentHeight = Math.max(400, (endTime - startTime) * 60 / interval * 16);
-
     // UTC JS offsets are "-1 *" of how they're displayed.
     let operator = localOffset < 0 ? '+' : '-';
     $('.js-localTimezone').text(`(${localName} UTC ${operator}${Math.abs(localOffset)})`);
@@ -63,7 +66,7 @@ $( document ).ready(function() {
       views: {
         resourceTimeGridFourDay: {
           type: 'resourceTimeGrid',
-          duration: { days: 4 },
+          duration: { days: width },
           buttonText: 'overview',
           datesAboveResources: true
         },


### PR DESCRIPTION
- Hide overview button if the event is 1 day
- Make the overview "width" 2 or 3 days for events < 4 days.
- Issue Link: https://github.com/snap-cloud/snapcon/issues/215