### PR TITLE
Fix #225 add an all events selection to the navbar

### DIFF
--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -25,8 +25,6 @@
               %em> !
           %li
             = link_to 'Forum', 'https://forum.snap.berkeley.edu', target: '_blank'
-          -# %li
-          -#   = link_to 'Learning Festival', '/conferences/ylf2021'
           %li.dropdown
             %a.dropdown-toggle{"data-toggle" => "dropdown", href: '#', id: "all-events"}
               All Events

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -19,27 +19,7 @@
       - if content_for :splash_nav
         %ul.nav.navbar-nav#splash-nav
           = content_for :splash_nav
-          %li
-            = link_to 'https://snap.berkeley.edu', target: '_blank' do
-              Snap
-              %em> !
-          %li
-            = link_to 'Forum', 'https://forum.snap.berkeley.edu', target: '_blank'
-          %li.dropdown
-            %a.dropdown-toggle{"data-toggle" => "dropdown", href: '#', id: "all-events"}
-              All Events
-              %b.caret
-            %ul.dropdown-menu
-              - conference_orgs = Conference.all.select { |conference| can?(:show, conference) }.group_by(&:organization)
-              - conference_orgs.each do |org, conferences|
-                %li.dropdown-header
-                  = org.name
-                - conferences.sort_by(&:start_date).each do |conference|
-                  - if conference.id != @conference.id
-                    %li
-                      = link_to conference.title, conference_path(conference.short_title)
-                %li.divider
-
+          = render 'layouts/snapcon_nav', conference: @conference
       -if user_signed_in?
         .btn-group.pull-right
           %ul.nav.navbar-nav.navbar-right

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -25,8 +25,22 @@
               %em> !
           %li
             = link_to 'Forum', 'https://forum.snap.berkeley.edu', target: '_blank'
-          %li
-            = link_to 'Learning Festival', '/conferences/ylf2021'
+          -# %li
+          -#   = link_to 'Learning Festival', '/conferences/ylf2021'
+          %li.dropdown
+            %a.dropdown-toggle{"data-toggle" => "dropdown", href: '#', id: "all-events"}
+              All Events
+              %b.caret
+            %ul.dropdown-menu
+              - conference_orgs = Conference.all.select { |conference| can?(:show, conference) }.group_by(&:organization)
+              - conference_orgs.each do |org, conferences|
+                %li.dropdown-header
+                  = org.name
+                - conferences.sort_by(&:start_date).each do |conference|
+                  - if conference.id != @conference.id
+                    %li
+                      = link_to conference.title, conference_path(conference.short_title)
+                %li.divider
 
       -if user_signed_in?
         .btn-group.pull-right

--- a/app/views/layouts/_navigation.html.haml
+++ b/app/views/layouts/_navigation.html.haml
@@ -19,7 +19,7 @@
       - if content_for :splash_nav
         %ul.nav.navbar-nav#splash-nav
           = content_for :splash_nav
-          = render 'layouts/snapcon_nav', conference: @conference
+          = render 'layouts/snapcon_nav', conference: conference
       -if user_signed_in?
         .btn-group.pull-right
           %ul.nav.navbar-nav.navbar-right

--- a/app/views/layouts/_snapcon_nav.haml
+++ b/app/views/layouts/_snapcon_nav.haml
@@ -5,7 +5,7 @@
 %li
   = link_to 'Forum', 'https://forum.snap.berkeley.edu', target: '_blank'
 %li.dropdown
-  %a.dropdown-toggle{"data-toggle": "dropdown", href: '#', id: "all-events"}
+  %a.dropdown-toggle{'data-toggle': 'dropdown', href: '#', id: 'all-events' }
     All Events
     %b.caret
   %ul.dropdown-menu

--- a/app/views/layouts/_snapcon_nav.haml
+++ b/app/views/layouts/_snapcon_nav.haml
@@ -1,0 +1,20 @@
+%li
+  = link_to 'https://snap.berkeley.edu', target: '_blank' do
+    Snap
+    %em> !
+%li
+  = link_to 'Forum', 'https://forum.snap.berkeley.edu', target: '_blank'
+%li.dropdown
+  %a.dropdown-toggle{"data-toggle": "dropdown", href: '#', id: "all-events"}
+    All Events
+    %b.caret
+  %ul.dropdown-menu
+    - conference_orgs = Conference.all.select { |conf| can?(:show, conf) }.group_by(&:organization)
+    - conference_orgs.each do |org, conferences|
+      %li.dropdown-header
+        = org.name
+      - conferences.sort_by(&:start_date).each do |conf|
+        - if conf.id != conference.id
+          %li
+            = link_to conf.title, conference_path(conf.short_title)
+      %li.divider

--- a/app/views/layouts/_snapcon_nav.haml
+++ b/app/views/layouts/_snapcon_nav.haml
@@ -5,7 +5,7 @@
 %li
   = link_to 'Forum', 'https://forum.snap.berkeley.edu', target: '_blank'
 %li.dropdown
-  %a.dropdown-toggle{'data-toggle': 'dropdown', href: '#', id: 'all-events' }
+  %a.dropdown-toggle{ 'data-toggle': 'dropdown', href: '#', id: 'all-events' }
     All Events
     %b.caret
   %ul.dropdown-menu

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -27,7 +27,8 @@
         = @conference.custom_css.html_safe
 
   %body{ class: ("conference-#{@conference.short_title}" if @conference) }
-    = render 'layouts/navigation', conference: @conference
+    - cache ['navigation', current_user, @conference, controller_name] do
+      = render 'layouts/navigation', conference: @conference
     -# Admin area
     - if controller.class.name.split("::").first=="Admin"
       = render 'layouts/admin'


### PR DESCRIPTION
Adds an all events dropdown menu to the navbar.

Not super fancy, but groups the events by organization.