### PR TITLE
change to new event type view 

### DIFF
--- a/app/views/admin/event_types/_form.html.haml
+++ b/app/views/admin/event_types/_form.html.haml
@@ -24,7 +24,7 @@
     %abbr{title: 'This field is required'} *
     = f.number_field :maximum_abstract_length, size: 3, required: true, class: 'form-control'
   .form-group
-    = f.label :submission_instructions
+    = f.label :submission_instructions, 'Submission Template'
     = f.text_area :submission_instructions, rows: 5, data: { provide: 'markdown' }
     .help-block= markdown_hint
   .form-group


### PR DESCRIPTION
**Checklist**

- [x] I have read the [Contribution & Best practices Guide](https://github.com/openSUSE/osem/blob/master/CONTRIBUTING.md).
- [x] My branch is up-to-date with the upstream `master` branch.
- [x] The tests pass locally with my changes.
- [x] I have added tests that prove my fix is effective or that my feature works(if appropriate).
- [x] I have added necessary documentation (if appropriate).

**Short description of what this resolves/which [issues](https://github.com/openSUSE/osem/issues) does this fix?:**
<!-- List the issue number resolved with this change; if there is no open issue, describe the problem this request solves -->

- when creating new event type the view now shows 'Submission Template' rather than 'Submission Instructions'
- i didn't change the attribute name within the codebase only the view rendered when making a new event type

