### PR TITLE
187217062 enable public submission event types

### DIFF
--- a/app/controllers/admin/event_types_controller.rb
+++ b/app/controllers/admin/event_types_controller.rb
@@ -50,7 +50,7 @@ module Admin
 
     def event_type_params
       params.require(:event_type).permit(:title, :length, :minimum_abstract_length, :maximum_abstract_length,
-                                         :submission_template, :color, :conference_id, :description)
+                                         :submission_template, :color, :conference_id, :description, :enable_public_submission)
     end
   end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -49,7 +49,6 @@ class ProposalsController < ApplicationController
       authorize! :create, @user
       if @user.save
         sign_in(@user)
-        set_is_admin
       else
         flash.now[:error] = "Could not save user: #{@user.errors.full_messages.join(', ')}"
         render action: 'new'

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -216,6 +216,6 @@ class ProposalsController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :password, :password_confirmation, :username, :is_admin)
+    params.require(:user).permit(:email, :password, :password_confirmation, :username)
   end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -3,6 +3,7 @@
 class ProposalsController < ApplicationController
   include ConferenceHelper
   before_action :authenticate_user!, except: %i[show new create]
+  before_action :set_is_admin
   load_resource :conference, find_by: :short_title
   load_resource :program, through: :conference, singleton: true
   load_and_authorize_resource :event, parent: false, through: :program
@@ -31,12 +32,6 @@ class ProposalsController < ApplicationController
     @url = conference_program_proposals_path(@conference.short_title)
     @languages = @program.languages_list
     @superevents = @program.super_events
-
-    if current_user.is_admin?
-      @event_types = @program.event_types
-    else 
-      @event_types = @program.event_types.available_for_public
-    end 
   end
 
   def edit
@@ -224,4 +219,8 @@ class ProposalsController < ApplicationController
   def user_params
     params.require(:user).permit(:email, :password, :password_confirmation, :username)
   end
+
+  def set_is_admin
+    @is_admin = current_user.is_admin
+  end 
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -3,7 +3,6 @@
 class ProposalsController < ApplicationController
   include ConferenceHelper
   before_action :authenticate_user!, except: %i[show new create]
-  before_action :set_is_admin
   load_resource :conference, find_by: :short_title
   load_resource :program, through: :conference, singleton: true
   load_and_authorize_resource :event, parent: false, through: :program
@@ -50,6 +49,7 @@ class ProposalsController < ApplicationController
       authorize! :create, @user
       if @user.save
         sign_in(@user)
+        set_is_admin
       else
         flash.now[:error] = "Could not save user: #{@user.errors.full_messages.join(', ')}"
         render action: 'new'
@@ -217,10 +217,6 @@ class ProposalsController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:email, :password, :password_confirmation, :username)
+    params.require(:user).permit(:email, :password, :password_confirmation, :username, :is_admin)
   end
-
-  def set_is_admin
-    @is_admin = current_user.is_admin
-  end 
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -31,6 +31,12 @@ class ProposalsController < ApplicationController
     @url = conference_program_proposals_path(@conference.short_title)
     @languages = @program.languages_list
     @superevents = @program.super_events
+
+    if current_user.is_admin?
+      @event_types = @program.event_types
+    else 
+      @event_types = @program.event_types.available_for_public
+    end 
   end
 
   def edit

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,8 +122,16 @@ hint: options[:hint]
     end, ', ')
   end
 
-  def event_types_sentence(conference)
-    conference.event_types.map { |et| et.title.pluralize }.to_sentence
+  def event_types_sentence(conference, is_admin = true)
+    if is_admin
+      conference.event_types.map { |et| et.title.pluralize }.to_sentence
+    else 
+      conference.event_types.available_for_public.map { |et| et.title.pluralize }.to_sentence
+    end
+  end
+
+  def event_types_dropdown(conference, is_admin = true)
+    is_admin ? conference.event_types : conference.event_types.available_for_public
   end
 
   def sign_in_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -122,10 +122,10 @@ hint: options[:hint]
     end, ', ')
   end
 
-  def event_types_sentence(conference, is_admin = true)
+  def event_types_sentence(conference, is_admin)
     if is_admin
       conference.event_types.map { |et| et.title.pluralize }.to_sentence
-    else 
+    else
       conference.event_types.available_for_public.map { |et| et.title.pluralize }.to_sentence
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -130,10 +130,6 @@ hint: options[:hint]
     end
   end
 
-  def event_types_dropdown(conference, is_admin = true)
-    is_admin ? conference.event_types : conference.event_types.available_for_public
-  end
-
   def sign_in_path
     if ENV.fetch('OSEM_ICHAIN_ENABLED', nil) == 'true'
       new_user_ichain_session_path

--- a/app/helpers/event_types_helper.rb
+++ b/app/helpers/event_types_helper.rb
@@ -15,7 +15,7 @@ module EventTypesHelper
         { data: {
           min_words:    type.minimum_abstract_length,
           max_words:    type.maximum_abstract_length,
-          instructions: type.submission_template
+          template: type.submission_template
         } }
       ]
     end

--- a/app/helpers/event_types_helper.rb
+++ b/app/helpers/event_types_helper.rb
@@ -13,9 +13,9 @@ module EventTypesHelper
         "#{type.title} - #{show_time(type.length)}",
         type.id,
         { data: {
-          min_words:    type.minimum_abstract_length,
-          max_words:    type.maximum_abstract_length,
-          template: type.submission_template
+          min_words: type.minimum_abstract_length,
+          max_words: type.maximum_abstract_length,
+          template:  type.submission_template
         } }
       ]
     end

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -32,6 +32,7 @@ class EventType < ApplicationRecord
   validates :color, format: /\A#[0-9A-F]{6}\z/
 
   before_validation :capitalize_color
+  before_validation :strip_title
 
   alias_attribute :name, :title
 
@@ -57,7 +58,7 @@ class EventType < ApplicationRecord
     program.conference_id
   end
 
-  # def self.available_for_public_submission
-  #   is_admin? all : available_for_public
-  # end 
+  def strip_title
+    self.title = title.strip unless title.nil?
+  end
 end

--- a/app/models/event_type.rb
+++ b/app/models/event_type.rb
@@ -4,17 +4,18 @@
 #
 # Table name: event_types
 #
-#  id                      :bigint           not null, primary key
-#  color                   :string
-#  description             :string
-#  length                  :integer          default(30)
-#  maximum_abstract_length :integer          default(500)
-#  minimum_abstract_length :integer          default(0)
-#  submission_template     :text
-#  title                   :string           not null
-#  created_at              :datetime
-#  updated_at              :datetime
-#  program_id              :integer
+#  id                       :bigint           not null, primary key
+#  color                    :string
+#  description              :string
+#  enable_public_submission :boolean          default(TRUE), not null
+#  length                   :integer          default(30)
+#  maximum_abstract_length  :integer          default(500)
+#  minimum_abstract_length  :integer          default(0)
+#  submission_template      :text
+#  title                    :string           not null
+#  created_at               :datetime
+#  updated_at               :datetime
+#  program_id               :integer
 #
 class EventType < ApplicationRecord
   belongs_to :program, touch: true
@@ -33,6 +34,8 @@ class EventType < ApplicationRecord
   before_validation :capitalize_color
 
   alias_attribute :name, :title
+
+  scope :available_for_public, -> { where(enable_public_submission: true) }
 
   private
 
@@ -53,4 +56,8 @@ class EventType < ApplicationRecord
   def conference_id
     program.conference_id
   end
+
+  # def self.available_for_public_submission
+  #   is_admin? all : available_for_public
+  # end 
 end

--- a/app/views/admin/cfps/_events_cfp.html.haml
+++ b/app/views/admin/cfps/_events_cfp.html.haml
@@ -21,7 +21,7 @@
 %dt
   Event types:
 %dd
-  = event_types_sentence(conference)
+  = event_types_sentence(conference, true)
 %dt
   Tracks:
 %dd

--- a/app/views/admin/event_types/_form.html.haml
+++ b/app/views/admin/event_types/_form.html.haml
@@ -18,8 +18,6 @@
   .form-group
     = f.label "Allow public submission?", for: :enable_public_submission
     = f.check_box :enable_public_submission, class: 'switch-checkbox'
-    .help-block
-      Do we need description for explanation?
   .form-group
     = f.label :minimum_abstract_length
     %abbr{title: 'This field is required'} *

--- a/app/views/admin/event_types/_form.html.haml
+++ b/app/views/admin/event_types/_form.html.haml
@@ -16,6 +16,11 @@
     = f.text_area :description, class: 'form-control', rows: 5, data: { provide: 'markdown' }
     .help-block= markdown_hint
   .form-group
+    = f.label "Allow public submission?", for: :enable_public_submission
+    = f.check_box :enable_public_submission, class: 'switch-checkbox'
+    .help-block
+      Do we need description for explanation?
+  .form-group
     = f.label :minimum_abstract_length
     %abbr{title: 'This field is required'} *
     = f.number_field :minimum_abstract_length, size: 3, required: true, class: 'form-control'

--- a/app/views/admin/event_types/index.html.haml
+++ b/app/views/admin/event_types/index.html.haml
@@ -11,7 +11,8 @@
         %tr
           %th Title
           %th Description
-          %th Instructions
+          %th Enable Public Submission
+          %th Template
           %th Length
           %th Abstract Length
           %th Color
@@ -23,6 +24,8 @@
               = event_type.title
             %td
               = markdown(event_type.description)
+            %td
+              = event_type.enable_public_submission ? 'Yes' : 'No'
             %td
               = markdown(event_type.submission_template)
             %td

--- a/app/views/admin/programs/show.html.haml
+++ b/app/views/admin/programs/show.html.haml
@@ -22,7 +22,7 @@
         %dt
           Event types:
         %dd
-          = event_types_sentence(@conference)
+          = event_types_sentence(@conference, true)
         %dt
           Tracks:
         %dd

--- a/app/views/proposals/_encouragement_text.html.haml
+++ b/app/views/proposals/_encouragement_text.html.haml
@@ -1,7 +1,7 @@
 %p.lead
   - if @program.event_types.any?
     You can submit proposals for
-    = "#{event_types_sentence(@conference, @is_admin)}."
+    = "#{event_types_sentence(@conference, current_user.is_admin)}."
   - if @program.tracks.confirmed.cfp_active.any?
     Proposals should fit in one of the
     = "#{pluralize(@program.tracks.confirmed.cfp_active.count, 'track')}:"

--- a/app/views/proposals/_encouragement_text.html.haml
+++ b/app/views/proposals/_encouragement_text.html.haml
@@ -1,7 +1,7 @@
 %p.lead
   - if @program.event_types.any?
     You can submit proposals for
-    = "#{event_types_sentence(@conference, current_user.is_admin)}."
+    = "#{event_types_sentence(@conference, current_user&.is_admin || false)}."
   - if @program.tracks.confirmed.cfp_active.any?
     Proposals should fit in one of the
     = "#{pluralize(@program.tracks.confirmed.cfp_active.count, 'track')}:"

--- a/app/views/proposals/_encouragement_text.html.haml
+++ b/app/views/proposals/_encouragement_text.html.haml
@@ -1,7 +1,7 @@
 %p.lead
   - if @program.event_types.any?
     You can submit proposals for
-    = "#{event_types_sentence(@conference)}."
+    = "#{event_types_sentence(@conference, @is_admin)}."
   - if @program.tracks.confirmed.cfp_active.any?
     Proposals should fit in one of the
     = "#{pluralize(@program.tracks.confirmed.cfp_active.count, 'track')}:"

--- a/app/views/proposals/_submission_type_content_form.haml
+++ b/app/views/proposals/_submission_type_content_form.haml
@@ -3,7 +3,7 @@
 
 .form-group
   = f.label :event_type_id, "Type"
-  - if current_user.is_admin
+  - if current_user&.is_admin
     = f.select :event_type_id, event_type_select_options(@conference.program.event_types), { include_blank: false }, { class: 'select-help-toggle form-control' }
   - else
     = f.select :event_type_id, event_type_select_options(@conference.program.event_types.available_for_public), { include_blank: false }, { class: 'select-help-toggle form-control' }

--- a/app/views/proposals/_submission_type_content_form.haml
+++ b/app/views/proposals/_submission_type_content_form.haml
@@ -3,10 +3,8 @@
 
 .form-group
   = f.label :event_type_id, "Type"
-  - if current_user&.is_admin
-    = f.select :event_type_id, event_type_select_options(@conference.program.event_types), { include_blank: false }, { class: 'select-help-toggle form-control' }
-  - else
-    = f.select :event_type_id, event_type_select_options(@conference.program.event_types.available_for_public), { include_blank: false }, { class: 'select-help-toggle form-control' }
+  - visible_event_types = current_user&.is_admin ? @conference.program.event_types : @conference.program.event_types.available_for_public
+  = f.select :event_type_id, event_type_select_options(visible_event_types), { include_blank: false }, { class: 'select-help-toggle form-control' }
 
 - program.event_types.each do |event_type|
   .help-block.event_event_type_id.collapse{ id: "#{dom_id(event_type)}-help" }

--- a/app/views/proposals/_submission_type_content_form.haml
+++ b/app/views/proposals/_submission_type_content_form.haml
@@ -3,7 +3,10 @@
 
 .form-group
   = f.label :event_type_id, "Type"
-  = f.select :event_type_id, event_type_select_options(event_types_dropdown(@conference, @is_admin)), { include_blank: false }, { class: 'select-help-toggle form-control' }
+  - if current_user.is_admin
+    = f.select :event_type_id, event_type_select_options(@conference.program.event_types), { include_blank: false }, { class: 'select-help-toggle form-control' }
+  - else
+    = f.select :event_type_id, event_type_select_options(@conference.program.event_types.available_for_public), { include_blank: false }, { class: 'select-help-toggle form-control' }
 
 - program.event_types.each do |event_type|
   .help-block.event_event_type_id.collapse{ id: "#{dom_id(event_type)}-help" }

--- a/app/views/proposals/_submission_type_content_form.haml
+++ b/app/views/proposals/_submission_type_content_form.haml
@@ -2,8 +2,8 @@
 %p Please select a submission type, then fill in the abstract and extended details.
 
 .form-group
-  = f.label :event_type_id, 'Type'
-  = f.select :event_type_id, event_type_select_options(@conference.program.event_types), { include_blank: false }, { class: 'select-help-toggle form-control' }
+  = f.label :event_type_id, "Type"
+  = f.select :event_type_id, event_type_select_options(event_types_dropdown(@conference, @is_admin)), { include_blank: false }, { class: 'select-help-toggle form-control' }
 
 - program.event_types.each do |event_type|
   .help-block.event_event_type_id.collapse{ id: "#{dom_id(event_type)}-help" }

--- a/db/migrate/20240318164346_add_enable_public_submission_to_event_types.rb
+++ b/db/migrate/20240318164346_add_enable_public_submission_to_event_types.rb
@@ -1,0 +1,5 @@
+class AddEnablePublicSubmissionToEventTypes < ActiveRecord::Migration[7.0]
+  def change
+    add_column :event_types, :enable_public_submission, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_26_175634) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_18_164346) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
@@ -234,6 +234,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_26_175634) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.text "submission_template"
+    t.boolean "enable_public_submission", default: true, null: false
   end
 
   create_table "event_users", force: :cascade do |t|

--- a/spec/factories/event_types.rb
+++ b/spec/factories/event_types.rb
@@ -4,17 +4,18 @@
 #
 # Table name: event_types
 #
-#  id                      :bigint           not null, primary key
-#  color                   :string
-#  description             :string
-#  length                  :integer          default(30)
-#  maximum_abstract_length :integer          default(500)
-#  minimum_abstract_length :integer          default(0)
-#  submission_template     :text
-#  title                   :string           not null
-#  created_at              :datetime
-#  updated_at              :datetime
-#  program_id              :integer
+#  id                       :bigint           not null, primary key
+#  color                    :string
+#  description              :string
+#  enable_public_submission :boolean          default(TRUE), not null
+#  length                   :integer          default(30)
+#  maximum_abstract_length  :integer          default(500)
+#  minimum_abstract_length  :integer          default(0)
+#  submission_template      :text
+#  title                    :string           not null
+#  created_at               :datetime
+#  updated_at               :datetime
+#  program_id               :integer
 #
 
 FactoryBot.define do
@@ -22,6 +23,7 @@ FactoryBot.define do
     title { 'Example Event Type' }
     length { 30 }
     description { 'Example Event Description\nThis event type is an example.' }
+    enable_public_submission { true }
     minimum_abstract_length { 0 }
     maximum_abstract_length { 500 }
     submission_template { 'Example Event Template _with_ **markdown**' }

--- a/spec/features/currency_conversions_spec.rb
+++ b/spec/features/currency_conversions_spec.rb
@@ -22,7 +22,6 @@ describe CurrencyConversion do
       fill_in 'currency_conversion_from_currency', with: 'USD'
       fill_in 'currency_conversion_to_currency', with: 'EUR'
       fill_in 'currency_conversion_rate', with: '0.89'
-
       click_button 'Create Currency conversion'
       page.find('#flash')
       expect(flash).to eq('Currency conversion was successfully created.')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -155,4 +155,22 @@ start_time: conference.start_date + conference.start_hour.hours, room: create(:r
       expect(conference_logo_url(conference2)).to include('2.png')
     end
   end
+
+  describe '#event_type_sentence' do 
+    before do 
+      create(:event_type, title: 'Keynote', program: conference.program, enable_public_submission: false)
+    end 
+
+    context 'when a user is an admin' do 
+      it 'returns a sentence with all event types' do 
+        expect(helper.event_types_sentence(conference, true)).to eq 'Talks, Workshops, and Keynotes'
+      end 
+    end 
+
+    context 'when a user is not an admin' do 
+      it 'returns a sentence only event types that allow public submission' do 
+        expect(helper.event_types_sentence(conference, false)).to eq 'Talks and Workshops'
+      end 
+    end 
+  end 
 end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -156,21 +156,21 @@ start_time: conference.start_date + conference.start_hour.hours, room: create(:r
     end
   end
 
-  describe '#event_type_sentence' do 
-    before do 
+  describe '#event_type_sentence' do
+    before do
       create(:event_type, title: 'Keynote', program: conference.program, enable_public_submission: false)
-    end 
+    end
 
-    context 'when a user is an admin' do 
-      it 'returns a sentence with all event types' do 
+    context 'when a user is an admin' do
+      it 'returns a sentence with all event types' do
         expect(helper.event_types_sentence(conference, true)).to eq 'Talks, Workshops, and Keynotes'
-      end 
-    end 
+      end
+    end
 
-    context 'when a user is not an admin' do 
-      it 'returns a sentence only event types that allow public submission' do 
+    context 'when a user is not an admin' do
+      it 'returns a sentence only event types that allow public submission' do
         expect(helper.event_types_sentence(conference, false)).to eq 'Talks and Workshops'
-      end 
-    end 
-  end 
+      end
+    end
+  end
 end

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -63,24 +63,24 @@ describe EventType do
       end
     end
 
-    describe 'title' do 
-      it 'removes leading and trailing whitespace from title' do 
+    describe 'title' do
+      it 'removes leading and trailing whitespace from title' do
         event_type = EventType.new(title: '  Movie  ')
         event_type.valid?
         expect(event_type.title).to eq('Movie')
-      end 
-    end 
+      end
+    end
   end
 
   describe 'scope :available_for_public' do
     it 'includes event types with enable_public_submission set to true' do
       public_event_type = create(:event_type, program: conference.program, enable_public_submission: true)
       expect(EventType.available_for_public).to include(public_event_type)
-    end 
+    end
 
     it 'excludes event types with enable_public_submission set to false' do
       non_public_event_type = create(:event_type, program: conference.program, enable_public_submission: false)
       expect(EventType.available_for_public).not_to include(non_public_event_type)
-    end 
-  end 
+    end
+  end
 end

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -4,17 +4,18 @@
 #
 # Table name: event_types
 #
-#  id                      :bigint           not null, primary key
-#  color                   :string
-#  description             :string
-#  length                  :integer          default(30)
-#  maximum_abstract_length :integer          default(500)
-#  minimum_abstract_length :integer          default(0)
-#  submission_template     :text
-#  title                   :string           not null
-#  created_at              :datetime
-#  updated_at              :datetime
-#  program_id              :integer
+#  id                       :bigint           not null, primary key
+#  color                    :string
+#  description              :string
+#  enable_public_submission :boolean          default(TRUE), not null
+#  length                   :integer          default(30)
+#  maximum_abstract_length  :integer          default(500)
+#  minimum_abstract_length  :integer          default(0)
+#  submission_template      :text
+#  title                    :string           not null
+#  created_at               :datetime
+#  updated_at               :datetime
+#  program_id               :integer
 #
 require 'spec_helper'
 

--- a/spec/models/event_type_spec.rb
+++ b/spec/models/event_type_spec.rb
@@ -62,5 +62,25 @@ describe EventType do
         expect(build(:event_type, program: conference.program, length: 37)).not_to be_valid
       end
     end
+
+    describe 'title' do 
+      it 'removes leading and trailing whitespace from title' do 
+        event_type = EventType.new(title: '  Movie  ')
+        event_type.valid?
+        expect(event_type.title).to eq('Movie')
+      end 
+    end 
   end
+
+  describe 'scope :available_for_public' do
+    it 'includes event types with enable_public_submission set to true' do
+      public_event_type = create(:event_type, program: conference.program, enable_public_submission: true)
+      expect(EventType.available_for_public).to include(public_event_type)
+    end 
+
+    it 'excludes event types with enable_public_submission set to false' do
+      non_public_event_type = create(:event_type, program: conference.program, enable_public_submission: false)
+      expect(EventType.available_for_public).not_to include(non_public_event_type)
+    end 
+  end 
 end


### PR DESCRIPTION
### [Pivotal Tracker Link][tracker]

<!-- Complete this section filling in the link to a tracker story. -->
[tracker]: https://www.pivotaltracker.com/story/show/187217062

## What this PR does:
<!-- Complete the following sentence: -->

This pull request This pull request implements a new attribute enable_public_submission in the event_types model. This makes it so that when a new event type is created by an admin they can make it so that non admins can or cannot make proposals with this event type.

#### Who authored this PR?
<!-- Tag the names of any other contributors -->
@tiffanylamm 

### How should this PR be tested?
I added tests in the event types model spec as well as the application helper spec. It tests that the dropdown and description when a non admin/admin user creates a proposal they see what they should see.

#### Are there any complications to deploying this?

<!-- Data migrations, upgrades, etc. -->
This requires a migration to add the new attribute enable_public_submission in the event_types model.

### Checklist:

- [x] Has this been deployed to a staging environment or reviewed by a customer?
- [x] Tag someone for code review (either a coach / team member)
- [x] I have renamed the branch to match PivotTracker's suggested one (necessary for BlueJay)
