### PR TITLE
Fix ical nil event data

### DIFF
--- a/app/helpers/conference_helper.rb
+++ b/app/helpers/conference_helper.rb
@@ -35,6 +35,9 @@ module ConferenceHelper
   # adds events to icalendar for proposals in a conference
   def icalendar_proposals(calendar, proposals, conference)
     proposals.each do |proposal|
+      # some 2021 events have nil time or event_type
+      next if proposal.time.nil? || proposal.event_type.nil?
+
       calendar.event do |e|
         e.dtstart = proposal.time
         e.dtend = proposal.time + (proposal.event_type.length * 60)
@@ -49,7 +52,7 @@ module ConferenceHelper
         if v
           e.geo = v.latitude, v.longitude if v.latitude && v.longitude
           location = ''
-          location += "#{proposal.room.name} - " if proposal.room.name
+          location += "#{proposal.room.name} - " if proposal.room&.name
           location += " - #{v.street}, " if v.street
           location += "#{v.postalcode} #{v.city}, " if v.postalcode && v.city
           location += "#{v.country_name}, " if v.country_name

--- a/spec/helpers/conference_helper_spec.rb
+++ b/spec/helpers/conference_helper_spec.rb
@@ -79,6 +79,60 @@ describe ConferenceHelper, type: :helper do
     end
   end
 
+  describe '#icalendar_proposals' do
+    let!(:conference_with_venue) do
+      create(:conference, venue: create(:venue))
+    end
+    let!(:contact_for_venue_conf) { create(:contact, conference: conference_with_venue) }
+    context 'when an event has a nil event_type' do
+      it 'skips the event and adds no VEVENT to the calendar' do
+        cal = Icalendar::Calendar.new
+        event = create(:event, program: conference_with_venue.program)
+        # Bypass validation to simulate legacy 2021 data with nil event_type
+        event.update_column(:event_type_id, nil)
+        event.reload
+
+        icalendar_proposals(cal, [event], conference_with_venue)
+        expect(cal.events).to be_empty
+      end
+    end
+
+    context 'when an event has a nil time (no event_schedule for selected schedule)' do
+      it 'skips the event and adds no VEVENT to the calendar' do
+        cal = Icalendar::Calendar.new
+        event = create(:event, program: conference_with_venue.program)
+        # Event exists but has no event_schedule, so event.time returns nil
+
+        icalendar_proposals(cal, [event], conference_with_venue)
+        expect(cal.events).to be_empty
+      end
+    end
+
+    context 'when an event has a nil room and conference has a venue' do
+      it 'still adds the event but builds location without room name' do
+        cal = Icalendar::Calendar.new
+        event = create(:event_scheduled, program: conference_with_venue.program)
+        # Nullify the room on the event_schedule to simulate missing room data
+        event.event_schedules.each { |es| es.update_column(:room_id, nil) }
+
+        icalendar_proposals(cal, [event], conference_with_venue)
+        expect(cal.events.size).to eq(1)
+        expect(cal.events.first.summary).to eq(event.title)
+      end
+    end
+
+    context 'with valid events' do
+      it 'adds the event to the calendar with correct summary' do
+        cal = Icalendar::Calendar.new
+        event = create(:event_scheduled, program: conference_with_venue.program)
+
+        icalendar_proposals(cal, [event], conference_with_venue)
+        expect(cal.events.size).to eq(1)
+        expect(cal.events.first.summary).to eq(event.title)
+      end
+    end
+  end
+
   describe '#get_happening_next_events_schedules' do
     let!(:conference2) do
       create(:full_conference, start_date: 1.day.ago, end_date: 7.days.from_now, start_hour: 0, end_hour: 24)


### PR DESCRIPTION
**What this PR does:**                                                                                                    
                                                                       
  - Fixes a crash in iCal calendar generation when events have nil time, event_type, or room data (seen
  in legacy 2021 conference data).

**Include screenshots, videos, etc.**

  - N/A: backend fix, no UI changes.

**Who authored this PR?**
  @sikesbc 

**How should this PR be tested?**

  - No deploy needed. This is a helper-level fix.
  - New specs in spec/helpers/conference_helper_spec.rb cover the four cases: nil event_type, nil time, nil room with a
  venue, and valid events.
  - Edge cases to watch: any conference with incomplete event data (missing schedules, rooms, or event types) should now
   generate iCal output without errors instead of raising NoMethodError.

**Are there any complications to deploying this?**

  - No migrations or data changes, just a guard clause and a safe navigation operator.